### PR TITLE
Solved bug in Boxplot with oral data due to missing labels for AVAL (AVALU=NA)

### DIFF
--- a/R/flexible_violinboxplot.R
+++ b/R/flexible_violinboxplot.R
@@ -34,7 +34,7 @@ flexible_violinboxplot <- function(result_data,
   # # xlabel of violin/boxplot
   dose_label = paste0("Dose [",  paste0(unique(box_data$DOSEU)), ']')
   # ylabel of violin/boxplot
-  col_name <- if (box_data$AVALU[1] == "unitless") {
+  col_name <- if (box_data$AVALU[1] == "unitless" | is.na(box_data$AVALU[1]) | is.null(box_data$AVALU)) {
     parameter} else {
       paste(parameter," [", box_data$AVALU[1], "]")
     }

--- a/R/flexible_violinboxplot.R
+++ b/R/flexible_violinboxplot.R
@@ -21,37 +21,38 @@ flexible_violinboxplot <- function(result_data,
                                    dosenumber_included,
                                    box = TRUE) {
   
-  
   # preprocess data to plot
   box_data <- result_data %>%
-    mutate(DOSEA_factor = as.factor(DOSEA)) %>% 
-    filter(PARAM == parameter) %>% 
-    # adapt DOSNO to be discrete with the fct_relevel library
-    mutate(DOSNO = as.factor(DOSNO)) %>%
-    filter(DOSEA %in% doses_included, 
-           DOSNO %in% dosenumber_included)
+    mutate(DOSEA = as.factor(DOSEA),
+           DOSNO = as.factor(DOSNO)) %>% 
+    filter(PPTESTCD == parameter,
+           DOSEA %in% doses_included,
+           DOSNO %in% dosenumber_included) 
   
   # # xlabel of violin/boxplot
-  dose_label = paste0("Dose [",  paste0(unique(box_data$DOSEU)), ']')
+  dose_label = if ('DOSEU' %in% names(box_data)) {
+                paste0("Dose [", unique(box_data$DOSEU)[1], "]")
+                } else {"Dose"}
+  
   # ylabel of violin/boxplot
-  col_name <- if (box_data$AVALU[1] == "unitless" | is.na(box_data$AVALU[1]) | is.null(box_data$AVALU)) {
+  pptestcd_label <- if (box_data$PPORRESU[1] == "unitless" | is.na(box_data$PPORRESU[1]) | is.null(box_data$PPORRESU)) {
     parameter} else {
-      paste(parameter," [", box_data$AVALU[1], "]")
+      paste(parameter," [", box_data$PPORRESU[1], "]")
     }
   # decide whether to layer violin or boxplot
   p <- if (box) {
-    ggplot(data = box_data, aes(x = DOSEA_factor, y = AVAL, color = DOSNO)) + geom_boxplot()
-      
+    ggplot(data = box_data, aes(x = DOSEA, y = PPORRES, color = DOSNO)) + geom_boxplot()
+    
   } else {
-    ggplot(data = box_data, aes(x = DOSEA_factor, y = AVAL, color = DOSNO)) + geom_violin()
+    ggplot(data = box_data, aes(x = DOSEA, y = PPORRES, color = DOSNO)) + geom_violin()
   }
   
   # add jitter, facet_wrap, and labels
   p +
     geom_point(position=position_jitterdodge()) +
-    # geom_smooth(method = "lm", color = "black") + # This is conceptually wrong, we need to do an ANOVA here
+    # geom_smooth(method = "lm", color = "black") + # Let's consider it for the future
     facet_wrap(~STUDYID) +
-    labs(x = dose_label, y = col_name, color = "Dose Number") +
+    labs(x = dose_label, y = pptestcd_label, color = "Dose Number") +
     theme(legend.position = "right",
           panel.spacing = unit(3, "lines"),
           strip.text = element_text(size = 10))

--- a/inst/shiny/tabs/outputs.R
+++ b/inst/shiny/tabs/outputs.R
@@ -72,7 +72,7 @@ output$individualplot <- renderPlotly({
   req(input$timescale)
   req(input$log)
 
-  # browser()
+  
   general_lineplot(data(),
                        input$generalplot_analyte,
                        input$generalplot_usubjid,
@@ -129,7 +129,7 @@ output$meanplot <- renderPlotly({
   req(input$studyidmean)
   req(input$analytemean)
   req(input$cyclesmean)
-  # browser()
+  
   general_meanplot(data(),
                        input$studyidmean,
                        input$analytemean,
@@ -155,7 +155,7 @@ output$meanplot <- renderPlotly({
 # pickerInput to filter for parameters to display in the summary table
 output$summaryselect <- renderUI({
   req(resNCA())
-  # browser()
+  
   # available parameters
   paramselection <- unique(resNCA()$result$PPTESTCD)
   # select from available with all perselected
@@ -318,7 +318,7 @@ output$norm_concovertimesemilog <- renderPlotly(
 
 # create formatted boxplot data -> also used for report
 boxplotdata <- reactive({
-  # browser()
+  
   reshape_PKNCA_results(resNCA()) %>%
   select(-starts_with("start"), -starts_with("end"), -starts_with("exclude"), -starts_with("lambda.z")) %>%
     left_join(resNCA()$data$conc$data %>%
@@ -328,7 +328,7 @@ boxplotdata <- reactive({
                  names_to = "PARAM", values_to = "AVAL") %>%
     left_join(resNCA()$result %>% select(PPTESTCD, PPORRESU) %>% distinct(), by = c("PARAM" = "PPTESTCD")) %>%
     rename("AVALU" = "PPORRESU")
-  # browser()
+  
 })
 
 # select which parameter to box or violin plot
@@ -389,7 +389,7 @@ output$violin_toggle <- renderUI({
 
 # compute the boxplot
 output$boxplot <- renderPlot({
-  # browser()
+  
   req(boxplotdata())
   req(input$boxplotparam)
   req(input$display_dose_boxplot)
@@ -409,7 +409,7 @@ output$boxplot <- renderPlot({
 #     paste("CDISC_", Sys.Date(), ".zip", sep = "")
 #   },
 #   content = function(file) {
-#     # browser()
+#     
 #     # Export the list of dataframes to a zip file containing CSVs
 #     rio::export_list(x = exportCDISC(resNCA()),
 #                      file = paste("%s_", Sys.Date(), ".csv", sep = ""), # filename from above is somehow not passed here?
@@ -486,7 +486,7 @@ output$download_rmd <- downloadHandler(
     paste("report/SD_report", "html", sep = ".")
   },
   content = function(file) {
-    # browser()
+    
     file.copy(rendered_rmd(), file)
   },
   contentType = "text/html"
@@ -501,7 +501,7 @@ output$download_rmd <- downloadHandler(
 #     # Copy the report template to a temporary directory
 #     tempReport <- file.path(tempdir(), "report.Rmd")
 #     file.copy("report/report.Rmd", tempReport, overwrite = TRUE)
-#     # browser()
+#     
 #     browser()
 #     # Set up parameters to pass to Rmd document
 #     params <- list(

--- a/inst/shiny/tabs/outputs.R
+++ b/inst/shiny/tabs/outputs.R
@@ -316,15 +316,15 @@ output$norm_concovertimesemilog <- renderPlotly(
 
 # TAB: Parameter Boxplots ----------------------------------------------------
 
-# create formatted boxplot data -> also used for report
+# Create formatted Boxplot data: PKNCAconc + PP results, linking DOSEA + PPTESTCD
 boxplotdata <- reactive({
-  
-  # Merge PKNCAconc to PP results so user can also access DOSEA within PPTESTCDs
-  merge(resNCA()$result,
-        resNCA()$data$conc$data, 
-        by=unname(unlist(resNCA()$data$conc$columns$groups))
+  group_columns = unname(unlist(resNCA()$data$conc$columns$groups))
+
+  left_join(resNCA()$result,
+        resNCA()$data$conc$data %>% distinct(across(all_of(group_columns)), .keep_all = T), 
+        by=group_columns,
+        keep = F
   )
-  
 })
 
 # select which parameter to box or violin plot
@@ -396,7 +396,7 @@ output$boxplot <- renderPlot({
                          input$boxplotparam,
                          input$display_dose_boxplot,
                          input$display_dosenumber_boxplot,
-                         input$violinplot_toggle_switch)
+                         input$violinplot_toggle_switch) 
 
 })
 


### PR DESCRIPTION
There was no unit value defined in the ORAL dataset (missing, NA) which was producing that an if() condition was neither T/F. Issue was solved addressing the condition is.na() | is.null() for cases when this label for the plot is missing or is unitless. 

**Checks**

- [x] Boxplots still work when exclusions/inclusions are considered after running NCA
- [x] Boxplots operate in all datasets, despite missing or null arbitrary columns (DOSEU)