### PR TITLE
Bug: Slope selection save

### DIFF
--- a/inst/shiny/tabs/nca.R
+++ b/inst/shiny/tabs/nca.R
@@ -644,7 +644,6 @@ output$slope_manual_NCA_data <- DT::renderDataTable(datatable(data=slope_manual_
 # Ensure edits are saved in slope data
 observeEvent(input$slope_manual_NCA_data_cell_edit, {
   info <- input$slope_manual_NCA_data_cell_edit
-  str(info)  # For debugging purposes, you can print the edit info
 
   # Update the reactive data frame with the new value
   slope_manual_NCA_data <- slope_manual_NCA_data()

--- a/inst/shiny/tabs/nca.R
+++ b/inst/shiny/tabs/nca.R
@@ -641,6 +641,17 @@ output$slope_manual_NCA_data <- DT::renderDataTable(datatable(data=slope_manual_
                                          drawCallback=JS('function() { Shiny.bindAll(this.api().table().node()); } ')
                                          )))
 
+# Ensure edits are saved in slope data
+observeEvent(input$slope_manual_NCA_data_cell_edit, {
+  info <- input$slope_manual_NCA_data_cell_edit
+  str(info)  # For debugging purposes, you can print the edit info
+
+  # Update the reactive data frame with the new value
+  slope_manual_NCA_data <- slope_manual_NCA_data()
+  slope_manual_NCA_data[info$row, (info$col+1)] <- info$value
+  slope_manual_NCA_data(slope_manual_NCA_data)
+})
+
 output$slope_manual_NCA_data2 <- renderTable(update_slope_manual_NCA_data(slope_manual_NCA_data()[,c(1:5)]))
 
 rowCounter <- reactiveVal(0) # Initialize a counter for the number of exclusions  


### PR DESCRIPTION
Slope selection did not save correctly when edits were made

**Checks**

- [x] Slope selections added and correctly saved in output table, nca results and slopes table. (with reasons also saved)