### PR TITLE
Enhancement/flexible axis boxplots

### DIFF
--- a/R/flexible_violinboxplot.R
+++ b/R/flexible_violinboxplot.R
@@ -58,7 +58,7 @@ flexible_violinboxplot <- function(boxplotdata,
 
   # Make the plot
   p = ggplot(data = box_data %>% arrange(!!!syms(colorvars)),
-             aes(x = interaction(!!!syms(xvars)), 
+             aes(x = interaction(!!!syms(xvars), sep = '\n'), 
                  y = PPORRES, 
                  color = interaction(!!!syms(colorvars)))) 
   

--- a/R/flexible_violinboxplot.R
+++ b/R/flexible_violinboxplot.R
@@ -16,66 +16,67 @@
 #' @export
 
 
-flexible_violinboxplot <- function(result_data, 
+flexible_violinboxplot <- function(boxplotdata, 
                                    parameter, 
-                                   doses_included,
-                                   dosenumber_included,
+                                   xvars,
+                                   colorvars,
+                                   varvalstofilter,
                                    columns_to_hover,
                                    box = TRUE) {
-  # preprocess data to plot
-  box_data <- result_data %>%
-    mutate(DOSEA = as.factor(DOSEA),
-           DOSNO = as.factor(DOSNO)) %>% 
-    filter(PPTESTCD == parameter,
-           DOSEA %in% doses_included,
-           DOSNO %in% dosenumber_included) 
+
+  # Variables to use to filter
+  vals_tofilter = gsub('.*: (.*)', '\\1', varvalstofilter)
+  vars_tofilter =  gsub('(.*): .*', '\\1', varvalstofilter)
+  var_types = sapply(vars_tofilter , \(col_id) class(boxplotdata[[col_id]]), USE.NAMES = F)
   
-  # # xlabel of violin/boxplot
-  dose_label = if ('DOSEU' %in% names(box_data)) {
-    paste0("Dose [", unique(box_data$DOSEU)[1], "]")
-  } else {"Dose"}
+  filter_text = paste0(
+    sapply(unique(vars_tofilter), \(varid){
+      vartype = class(boxplotdata[[varid]])
+      paste0(varid, " %in% as.", vartype, "(c('", paste0(vals_tofilter[vars_tofilter==varid], collapse="','"), "'))" 
+            )
+    }), collapse = " & "
+  )
   
-  # ylabel of violin/boxplot
-  pptestcd_label <- if (box_data$PPORRESU[1] == "unitless" | is.na(box_data$PPORRESU[1]) | is.null(box_data$PPORRESU)) {
-    parameter} else {
-      paste(parameter," [", box_data$PPORRESU[1], "]")
-    }
+  # Filter the data
+  box_data = boxplotdata %>% 
+    filter(eval(parse(text=filter_text)),
+           PPTESTCD == parameter)
   
-  # Create the hover text for the points dynamically, including also X,Y column values
-  columns_to_hover = c(columns_to_hover, 'DOSEA', 'PPORRES')
-  
+  # Hover text to identify each point
   hover_text <- apply(box_data[columns_to_hover] %>% 
                         mutate(across(where(is.numeric), round, digits = 2)), 
                       MARGIN = 1,
                       function(row) {
                         paste(names(row), row, sep = ": ", collapse = "<br>")
                       })
-  # decide whether to layer violin or boxplot
-  if (box) {
-    p = ggplot(data = box_data %>% arrange(DOSNO), 
-               aes(x = DOSEA, y = PPORRES, color = DOSNO)) + geom_boxplot()
-    
-  } else {
-    p = ggplot(data = box_data %>% arrange(DOSNO), 
-               aes(x = DOSEA, y = PPORRES, color = DOSNO)) 
-    # Make sure there is at least 1 group of 2 points
-    if (box_data %>% group_by(DOSEA) %>% filter(n()>1) %>% nrow()>0 ){
-      p = p + geom_violin()
-    }
-    
-  }
   
-  # add jitter, facet_wrap, and labels
-  p = p +
+  # ylabel of violin/boxplot
+  ylabel <- if (box_data$PPORRESU[1] == "unitless" | is.na(box_data$PPORRESU[1]) | is.null(box_data$PPORRESU)) {
+    parameter
+    } else {paste(parameter," [", box_data$PPORRESU[1], "]")}
+  
+
+  # Make the plot
+  p = ggplot(data = box_data %>% arrange(!!!syms(colorvars)),
+             aes(x = interaction(!!!syms(xvars)), 
+                 y = PPORRES, 
+                 color = interaction(!!!syms(colorvars)))) 
+  
+  #  Make boxplot or violin
+  if (box) {p = p + geom_boxplot()} else p = p + geom_violin()
+  
+  # Include points, labels and theme
+  p = p + 
     geom_point(position=position_jitterdodge(), aes(text=hover_text)) +
-    # geom_smooth(method = "lm", color = "black") + # Let's consider it for the future
-    facet_wrap(~STUDYID) +
-    labs(x = dose_label, y = pptestcd_label, color = "Dose Number") +
+    # facet_wrap(~STUDYID) +
+    labs(x = paste(xvars, collapse=', '), 
+         y = ylabel, 
+         color = paste(colorvars, collapse=', ') ) +
     theme_bw() + 
     theme(legend.position = "right",
           panel.spacing = unit(3, "lines"),
-          strip.text = element_text(size = 10)) 
+          strip.text = element_text(size = 10))
   
-  ggplotly(p, tooltip = 'text')
-  
+  # Make plotly with hover features
+  return(ggplotly(p, tooltip = 'text'))
 }

--- a/inst/shiny/tabs/outputs.R
+++ b/inst/shiny/tabs/outputs.R
@@ -346,6 +346,51 @@ output$selectboxplot <- renderUI({
 
 })
 
+
+
+
+# Selector for the variables to segregate boxplots in the x axis 
+output$select_xvars_boxplot <- renderUI({
+  
+  pickerInput(inputId = 'selected_xvars_boxplot', 
+              label = 'Select X grouping variables',
+              multiple = T,
+              choices = intersect(names(boxplotdata()), names(data())),
+              selected = 'DOSEA' 
+              )
+})
+
+
+
+observeEvent(input$selected_xvars_boxplot,{
+  
+  xvar_options_list = lapply(input$selected_xvars_boxplot, 
+                             \(id_var) unique(boxplotdata()[[id_var]]))
+  
+  names(xvar_options_list) = input$selected_xvars_boxplot
+  
+  updatePickerInput(session = session, 
+                    inputId = 'selected_xvals_boxplot', 
+                    label = 'Select values to display for grouping',
+                    choices = xvar_options_list, 
+                    selected = unlist(xvar_options_list)
+  )
+}
+)
+
+
+output$select_colorvars_boxplot <- renderUI({
+  
+  pickerInput(inputId = 'selected_colorvars_boxplot', 
+              label = 'Select coloring variables to differentiate boxplots',
+              multiple = T,
+              choices = intersect(names(boxplotdata()), names(data())),
+              selected = 'DOSNO' 
+  )
+})
+
+
+
 # filter for dose amounts to display in the boxplot
 output$display_dose_boxplot <- renderUI({
 

--- a/inst/shiny/tabs/outputs.R
+++ b/inst/shiny/tabs/outputs.R
@@ -338,7 +338,7 @@ output$selectboxplot <- renderUI({
   
   param_choices <- boxplotdata()$PPTESTCD %>% unique()
   
-  pickerInput("boxplotparam", "Choose the parameter to display:",
+  pickerInput("selected_param_boxplot", "Choose the parameter to display:",
               choices = param_choices,
               selected = param_choices[1],
               multiple = FALSE,
@@ -361,24 +361,6 @@ output$select_xvars_boxplot <- renderUI({
 })
 
 
-
-observeEvent(input$selected_xvars_boxplot,{
-  
-  xvar_options_list = lapply(input$selected_xvars_boxplot, 
-                             \(id_var) unique(boxplotdata()[[id_var]]))
-  
-  names(xvar_options_list) = input$selected_xvars_boxplot
-  
-  updatePickerInput(session = session, 
-                    inputId = 'selected_xvals_boxplot', 
-                    label = 'Select values to display for grouping',
-                    choices = xvar_options_list, 
-                    selected = unlist(xvar_options_list)
-  )
-}
-)
-
-
 output$select_colorvars_boxplot <- renderUI({
   
   pickerInput(inputId = 'selected_colorvars_boxplot', 
@@ -390,39 +372,24 @@ output$select_colorvars_boxplot <- renderUI({
 })
 
 
-
-# filter for dose amounts to display in the boxplot
-output$display_dose_boxplot <- renderUI({
-
-  param_choices <- sort(unique(boxplotdata()$DOSEA))
-
-  # filter for DOSEA with more than one observation
-  preselected_choices <- boxplotdata() %>%
-    group_by(DOSEA) %>%
-    summarise(n = n()) %>%
-    filter(n > 1) %>%
-    pull(DOSEA)
+observeEvent(list(input$selected_xvars_boxplot, input$selected_colorvars_boxplot),{
   
-  pickerInput("display_dose_boxplot", "Choose the doses amounts to display",
-              choices = param_choices,
-              selected = preselected_choices,
-              multiple = TRUE,
-              options = list(`actions-box` = TRUE))
-
-})
-
-# filter for dose numbers to display in the boxplot
-output$display_dosenumber_boxplot <- renderUI({
+  xvar_options_list = lapply(c(input$selected_xvars_boxplot, 
+                               input$selected_colorvars_boxplot), 
+                             \(id_var) paste(id_var, unique(boxplotdata()[[id_var]]), sep = ': '))
   
-  # deselect choices that are no pp parameters
-  param_choices <- sort(unique(boxplotdata()$DOSNO))
-  pickerInput("display_dosenumber_boxplot", "Choose the dose numbers to display",
-              choices = param_choices,
-              selected = param_choices,
-              multiple = TRUE,
-              options = list(`actions-box` = TRUE))
+  names(xvar_options_list) = c(input$selected_xvars_boxplot, 
+                               input$selected_colorvars_boxplot)
   
-})
+  updatePickerInput(session = session, 
+                    inputId = 'selected_varvalstofilter_boxplot', 
+                    label = 'Select values to display for grouping',
+                    choices = xvar_options_list, 
+                    selected = unlist(xvar_options_list)
+  )
+}
+)
+
 
 # toggle between boxplot and violinplot
 output$violin_toggle <- renderUI({
@@ -439,14 +406,16 @@ output$violin_toggle <- renderUI({
 output$boxplot <- renderPlotly({
   
   req(boxplotdata())
-  req(input$boxplotparam)
-  req(input$display_dose_boxplot)
-  req(input$display_dosenumber_boxplot)
-
-  flexible_violinboxplot(result_data = boxplotdata(),
-                         parameter = input$boxplotparam,
-                         doses_included = input$display_dose_boxplot,
-                         dosenumber_included = input$display_dosenumber_boxplot,
+  req(input$selected_param_boxplot)
+  req(input$selected_xvars_boxplot)
+  req(input$selected_colorvars_boxplot)
+  req(input$selected_varvalstofilter_boxplot)
+  
+  flexible_violinboxplot(boxplotdata = boxplotdata(),
+                         parameter = input$selected_param_boxplot,
+                         xvars = input$selected_xvars_boxplot,
+                         colorvars = input$selected_colorvars_boxplot,
+                         varvalstofilter = input$selected_varvalstofilter_boxplot,
                          columns_to_hover = unname(unlist(resNCA()$data$conc$columns$groups)),
                          box = input$violinplot_toggle_switch) 
 

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -522,6 +522,17 @@ shinyUI(fluidPage(
 
                          tabPanel("Box Plots",
                                   uiOutput("selectboxplot"),
+                                  uiOutput('select_xvars_boxplot'),
+                                  pickerInput(inputId = 'selected_xvals_boxplot', 
+                                              label = 'Select values to display for grouping',
+                                              multiple = T,
+                                              choices = NULL, 
+                                              selected = NULL,
+                                              options = list(`actions-box` = TRUE)
+                                              ),
+                                  uiOutput('select_colorvars_boxplot'),
+                                  
+                                  
                                   uiOutput("display_dose_boxplot"),
                                   uiOutput("display_dosenumber_boxplot"),
                                   uiOutput("violin_toggle"),

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -4,8 +4,7 @@ shinyUI(fluidPage(
   tags$script("
     Shiny.addCustomMessageHandler('update', function(value) {
     Shiny.setInputValue('update', value);
-    });
-  "),
+    }); "),
 
   tags$script("
     Shiny.addCustomMessageHandler('increment', function(value) {
@@ -523,25 +522,16 @@ shinyUI(fluidPage(
                          tabPanel("Box Plots",
                                   uiOutput("selectboxplot"),
                                   uiOutput('select_xvars_boxplot'),
-                                  pickerInput(inputId = 'selected_xvals_boxplot', 
-                                              label = 'Select values to display for grouping',
+                                  uiOutput('select_colorvars_boxplot'),
+                                  pickerInput(inputId = 'selected_varvalstofilter_boxplot', 
+                                              label = 'Select values to display',
                                               multiple = T,
                                               choices = NULL, 
                                               selected = NULL,
                                               options = list(`actions-box` = TRUE)
                                               ),
-                                  uiOutput('select_colorvars_boxplot'),
-                                  
-                                  
-                                  uiOutput("display_dose_boxplot"),
-                                  uiOutput("display_dosenumber_boxplot"),
                                   uiOutput("violin_toggle"),
                                   plotlyOutput('boxplot')
-                                  # plotlyOutput("cmaxboxplot"),
-                                  # br(),
-                                  # plotlyOutput("aucboxplot"),
-
-
                                   )
 
 


### PR DESCRIPTION
## Issue

Closes #

## Description
Boxplots include now more flexibility for the user to choose in the X axis as many variables as they want as well as to filter values or to choose how to color the boxplot 


## Definition of Done
- [x] Create ability to change x axis based on user input selecting Grouping category
- [x] Include options to group by more than one category (eg Dose and Age)- similar to descriptive stats

## How to test
NCA > Choose the analyte > Submit > Settings > Choose the Dose Number > Run NCA > Outputs > Dose Escalation > Boxplot


## Contributor checklist
- [x] X axis changes based on user input with 1 or more categories
- [x] Color changes based on user input with 1 or more categories
- [x] Boxplots are modified accordingly when values are filtered
