### PR TITLE
Bug: make slope selector cursor accurate

### DIFF
--- a/R/lambda_slope_plot.R
+++ b/R/lambda_slope_plot.R
@@ -225,7 +225,7 @@ lambda_slope_plot <- function(
         plot_data$is.excluded.hl ~ "red",
         plot_data$IX %in% lambda_z_ix_rows$IX ~ "green",
         TRUE ~ "black"
-      ), size = 50, opacity = 0),  # Make points semi-transparent
+      ), size = 12, opacity = 1),  # Make points semi-transparent
       showlegend = FALSE  # Don't show this trace in the legend
     )
 


### PR DESCRIPTION
## Issue

Closes #57 

## Description

In Slope selector, when clicking a point for exclusion/selection, the click will only work when a hovering box of the point appears. This hovering box now pops up when the mouse is in the center of the point instead of further outside.

## Definition of Done

- [ ] The hovering message should appear when the mouse indicator is located at the center of the point

## How to test

NCA > Choose the analyte > Submit > Settings > Choose the Dose Number > Run NCA > NCA > Slope selector > Hover/click points

## Contributor checklist
- [ ] Code passes lintr checks
