### PR TITLE
Enhancement: fixed header for dt::datatables

### DIFF
--- a/inst/shiny/modules/tab_data.R
+++ b/inst/shiny/modules/tab_data.R
@@ -128,10 +128,12 @@ tab_data_server <- function(id) {
       req(data())
       DT::datatable(
         data(),
+        extensions = "FixedHeader",
         options = list(
           scrollX = TRUE,
           scrollY = TRUE,
-          lengthMenu = list(c(10, 25, -1), c("10", "25", "All"))
+          lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
+          fixedHeader = TRUE
         )
       )
     })

--- a/inst/shiny/tabs/nca.R
+++ b/inst/shiny/tabs/nca.R
@@ -232,10 +232,12 @@ output$datatable <- DT::renderDataTable({
   req(mydata())
   DT::datatable(
     data = mydata()$conc$data,
+    extensions = "FixedHeader",
     options = list(
       scrollX = TRUE,
       scrollY = TRUE,
-      lengthMenu = list(c(10, 25, -1), c("10", "25", "All"))
+      lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
+      fixedHeader = TRUE
     )
   )
 })
@@ -521,10 +523,12 @@ output$myresults <- DT::renderDataTable({
   req(final_res_nca())
   DT::datatable(
     data = final_res_nca(),
+    extensions = "FixedHeader",
     options = list(
       scrollX = TRUE,
       scrollY = TRUE,
       lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
+      fixedHeader = TRUE,
       columnDefs = list(list(
         visible = FALSE, targets = setdiff(colnames(final_res_nca()), input$params)
       ))
@@ -672,10 +676,13 @@ output$preslopesettings <- DT::renderDataTable({
   # Render the DT datatable object
   DT::datatable(
     data = preslopesettings,
+    extensions = "FixedHeader",
     options = list(
       scrollX = TRUE,
       scrollY = TRUE,
-      lengthMenu = list(c(10, 25, -1), c("10", "25", "All"))
+      lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
+      pageLength = -1, 
+      fixedHeader = TRUE
     )
   ) %>%
     formatStyle(
@@ -755,10 +762,12 @@ output$slope_manual_NCA_data <- DT::renderDataTable({
     escape = FALSE,
     rownames = FALSE,
     editable = TRUE,
+    extensions = "FixedHeader",
     options = list(
       paging = FALSE,
       ordering = FALSE,
       searching = FALSE,
+      fixedHeader = TRUE,
       preDrawCallback = JS("function() { Shiny.unbindAll(this.api().table().node()); }"),
       drawCallback = JS("function() { Shiny.bindAll(this.api().table().node()); } ")
     )

--- a/inst/shiny/tabs/outputs.R
+++ b/inst/shiny/tabs/outputs.R
@@ -218,10 +218,12 @@ output$descriptivestats <- DT::renderDataTable({
   req(summary_stats())
   DT::datatable(
     data = summary_stats(),
+    extensions = "FixedHeader",
     options = list(
       scrollX = TRUE,
       scrollY = TRUE,
-      lengthMenu = list(c(10, 25, -1), c("10", "25", "All"))
+      lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
+      fixedHeader = TRUE
     )
   )
 })
@@ -230,10 +232,12 @@ output$descriptivestats2 <- DT::renderDataTable({
   req(res_nca())
   DT::datatable(
     data = calculate_summary_stats(res_nca())  %>% rename(PARAM = PPTESTCD),
+    extensions = "FixedHeader",
     options = list(
       scrollX = TRUE,
       scrollY = TRUE,
-      lengthMenu = list(c(10, 25, -1), c("10", "25", "All"))
+      lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
+      fixedHeader = TRUE
     )
   )
 })


### PR DESCRIPTION
## Issue
#90 
Closes #
#90 
## Description
User requested that for vertically long and wide tables columns should not be missing from their view when scrolling down

## Definition of Done
User should be able to see column headings, and horizontal scroll bar in same screen.

## How to test
- [x] Confirm all DT::datatables present fixed headers in the tabs: Data, NCA, Outputs

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
