### PR TITLE
Enhancement/display pp adpp

### DIFF
--- a/R/export_cdisc.R
+++ b/R/export_cdisc.R
@@ -138,8 +138,6 @@ export_cdisc <- function(res_nca) {
     # Identify all dulicates (fromlast and fromfirst) and keep only the first one
     filter(!duplicated(paste0(USUBJID, DOSNO, PPTESTCD))) %>%
     ungroup() %>%
-    # Make all numeric columns with 3 decimals
-    mutate(across(where(is.numeric), ~ signif(.x, 3)))  %>%
     #  Recode PPTESTCD PKNCA names to CDISC abbreviations
     mutate(
       PPTESTCD = recode(

--- a/R/export_cdisc.R
+++ b/R/export_cdisc.R
@@ -70,14 +70,11 @@ export_cdisc <- function(res_nca) {
     "DOMAIN",
     "USUBJID",
     "PPSEQ",
+    "PPCAT",
     "PPGRPID",
-    # "DRUG",
-    # "PARAM",
-    # "PPDOSNO",
     "PPSPID",
     "PPTESTCD",
     "PPTEST",
-    "PPCAT",
     "PPSCAT",
     "PPORRES",
     "PPORRESU",
@@ -94,13 +91,14 @@ export_cdisc <- function(res_nca) {
 
   # define columns needed for adpp
   adpp_col <- c("STUDYID",
+                "DOMAIN",
                 "USUBJID",
-                "PPGRPID",
-                # "DRUG",
-                # "PARAM",
-                # "PPDOSNO",
-                # "PPSPEC",
+                "PPSEQ",
                 "PPCAT",
+                "PPGRPID",
+                "PPSPID",
+                "PPTESTCD",
+                "PPTEST",
                 "PPSCAT",
                 "PPREASND",
                 "PPSPEC",
@@ -116,8 +114,6 @@ export_cdisc <- function(res_nca) {
                 "AAGEU",
                 "TRT01P",
                 "TRT01A",
-                "PARAM",
-                "PARAMCD",
                 "AVAL",
                 "AVALC",
                 "AVALU")
@@ -179,7 +175,7 @@ export_cdisc <- function(res_nca) {
       PPSTAT = ifelse(is.na(PPORRES) | (PPORRES == 0 & PPTESTCD == "CMAX"), "NOT DONE",  ""),
       PPREASND = case_when(
         !is.na(exclude) ~ exclude,
-        is.na(PPORRES) ~ "Unespecified",
+        is.na(PPORRES) ~ "Unspecified",
         TRUE ~ ""
       ),
       # Datetime

--- a/R/export_cdisc.R
+++ b/R/export_cdisc.R
@@ -121,8 +121,8 @@ export_cdisc <- function(res_nca) {
   pp_info <- res_nca$result  %>%
     filter(is.infinite(end) | PPTESTCD == "auclast") %>%
     left_join(res_nca$data$dose$data,
-          by = unname(unlist(res_nca$data$dose$columns$groups)),
-          suffix= c("", ".y")) %>%
+              by = unname(unlist(res_nca$data$dose$columns$groups)),
+              suffix = c("", ".y")) %>%
     group_by(
       across(all_of(c(
         unname(unlist(res_nca$data$conc$columns$groups)), "start", "end", "PPTESTCD"

--- a/R/export_cdisc.R
+++ b/R/export_cdisc.R
@@ -203,16 +203,14 @@ export_cdisc <- function(res_nca) {
   # select pp columns
   pp <- pp_info %>%  select(all_of(pp_col))
 
-  # Include subject metadata and select adpp columns
   adpp <- pp_info %>%
     # Elude potential collapse cases with PC variables
-    .[!names(.) %in% c("AVAL", "AVALC", "AVALU")] %>%
+    select(-any_of(c("AVAL", "AVALC", "AVALU"))) %>%
     rename(AVAL = PPSTRESN, AVALC = PPSTRESC, AVALU = PPSTRESU)  %>%
-    merge(
+    left_join(
       res_nca$data$dose$data %>%
-        select(any_of(c("USUBJID", setdiff(names(res_nca$data$dose$data), names(pp_info))))),
-      all.x = TRUE,
-      all.y = FALSE
+        select(-any_of(setdiff(names(pp_info), "USUBJID"))),
+      by = "USUBJID"
     ) %>%
     select(any_of(adpp_col))
 

--- a/R/export_cdisc.R
+++ b/R/export_cdisc.R
@@ -28,17 +28,20 @@ pptestcd_dict <- setNames(
     "AUC to Last Nonzero Conc Norm by Dose", "Lambda z", "AUC to Last Nonzero Conc",
     "Half-Life Lambda z", "Number of points used for Lambda z", "Last Nonzero Conc Predicted",
     "Span Ratio", "Lambda z lower limit (time)",
-    
+
     # Manually filled
-    "Trough Concentration", "Average Concentration", "AUC Infinity Predicted", "AUMC Infinity Observed", "AUC Percent Extrapolated Observed", 
-    "AUC Percent Extrapolated Predicted", "Clearance Observed", "Clearance Predicted", "Mean Residence Time Intravenous Observed", "Volume of Distribution Observed", 
-    "Steady-State Volume of Distribution Intravenous Observed", "AUC Infinity Observed Dose-Normalized", "Maximum Concentration Dose-Normalized"
+    "Trough Concentration", "Average Concentration", "AUC Infinity Predicted",
+    "AUMC Infinity Observed", "AUC Percent Extrapolated Observed",
+    "AUC Percent Extrapolated Predicted", "Clearance Observed",
+    "Clearance Predicted", "Mean Residence Time Intravenous Observed",
+    "Volume of Distribution Observed",
+    "Steady-State Volume of Distribution Intravenous Observed",
+    "AUC Infinity Observed Dose-Normalized", "Maximum Concentration Dose-Normalized"
   ),
-  c(
-    "CLFO", "TLST", "CMAX", "VZFO", "AUCIFO", "CLST", "TMAX", "R2", "R2ADJ", "CMAXD", "AUCLSTD",
+  c("CLFO", "TLST", "CMAX", "VZFO", "AUCIFO", "CLST", "TMAX", "R2", "R2ADJ", "CMAXD", "AUCLSTD",
     "LAMZ", "AUCLST", "LAMZHL", "LAMZNPT", "CLSTP", "LAMZSPNR", "LAMZLL",
-    
-    "CTROUGH", "CAV", "AUCIFP", "AUMCINF.OBS", "AUCPEO", "AUCPEP", "CL.OBS", "CL.PRED", "MRT.IV.OBS", "VZ.OBS", "VSS.IV.OBS", "AUCINF.OBS.DN", "CMAX.DN"
+    "CTROUGH", "CAV", "AUCIFP", "AUMCINF.OBS", "AUCPEO", "AUCPEP", "CL.OBS", "CL.PRED",
+    "MRT.IV.OBS", "VZ.OBS", "VSS.IV.OBS", "AUCINF.OBS.DN", "CMAX.DN"
   )
 )
 
@@ -123,10 +126,9 @@ export_cdisc <- function(res_nca) {
     filter(is.infinite(end) | PPTESTCD == "auclast") %>%
     merge(res_nca$data$dose$data,
           by = unname(unlist(res_nca$data$dose$columns$groups)),
-          all.x = TRUE, 
+          all.x = TRUE,
           all.y = FALSE,
-          suffixes = c("", ".y")
-          ) %>% 
+          suffixes = c("", ".y")) %>%
     group_by(
       across(all_of(c(
         unname(unlist(res_nca$data$conc$columns$groups)), "start", "end", "PPTESTCD"
@@ -210,7 +212,7 @@ export_cdisc <- function(res_nca) {
   # Include subject metadata and select adpp columns
   adpp <- pp_info %>%
     # Elude potential collapse cases with PC variables
-    .[!names(.) %in% c("AVAL", "AVALC", "AVALU")] %>% 
+    .[!names(.) %in% c("AVAL", "AVALC", "AVALU")] %>%
     rename(AVAL = PPSTRESN, AVALC = PPSTRESC, AVALU = PPSTRESU)  %>%
     merge(
       res_nca$data$dose$data %>%

--- a/R/export_cdisc.R
+++ b/R/export_cdisc.R
@@ -61,8 +61,6 @@ export_cdisc <- function(res_nca) {
   }
 
 
-
-
   # define columns needed for pp
   pp_col <- c(
     "STUDYID",
@@ -138,8 +136,9 @@ export_cdisc <- function(res_nca) {
     # Identify all dulicates (fromlast and fromfirst) and keep only the first one
     filter(!duplicated(paste0(USUBJID, DOSNO, PPTESTCD))) %>%
     ungroup() %>%
-    #  mutate PPTESTCD to match metadata and recode the PPTESTCD to
-    #  match the PPTESTCD in the PPTESTCD data frame
+    # Make all numeric columns with 3 decimals
+    mutate(across(where(is.numeric), ~ signif(.x, 3)))  %>%
+    #  Recode PPTESTCD PKNCA names to CDISC abbreviations
     mutate(
       PPTESTCD = recode(
         PPTESTCD %>% toupper,
@@ -198,10 +197,8 @@ export_cdisc <- function(res_nca) {
       PPSTINT = ifelse(start != Inf, start, NA),
       PPENINT = ifelse(end != Inf, end, NA)
     )  %>%
-    # Include PPTEST (PPTESTCD descriptions)
+    # Map PPTEST CDISC descriptions using PPTESTCD CDISC names
     mutate(PPTEST = pptestcd_dict[PPTESTCD])  %>%
-    # Make all numeric columns with 3 decimals
-    mutate(across(where(is.numeric), ~ signif(.x, 3)))  %>%
     group_by(USUBJID)  %>%
     mutate(PPSEQ = if ("PCSEQ" %in% names(.)) PCSEQ else row_number())  %>%
     ungroup()

--- a/inst/shiny/tabs/outputs.R
+++ b/inst/shiny/tabs/outputs.R
@@ -414,55 +414,55 @@ output$boxplot <- renderPlotly({
 # Parameter datasets ------------------------------------------------------------------------
 
 # Create CDISC parameter datasets (PP, ADPP)
-  observeEvent(res_nca(), {
-    CDISC <- export_cdisc(res_nca())
+observeEvent(res_nca(), {
+  CDISC <- export_cdisc(res_nca())
 
-    output$pp_dataset <- DT::renderDataTable({
-      DT::datatable(
-        data = CDISC$pp,
-        rownames = FALSE,
-        extensions = c("FixedHeader", "Buttons"),
-        options = list(
-          scrollX = TRUE,
-          scrollY = TRUE,
-          searching = TRUE,
-          fixedColumns = TRUE,
-          fixedHeader = TRUE,
-          autoWidth = TRUE,
-          dom = "Bfrtip",
-          buttons = list(
-            list(
-              extend = "copy",
-              title = paste0("PP_Dataset", "_", Sys.Date())
-            ),
-            list(
-              extend = "csv",
-              title = paste0("PP_Dataset", "_", Sys.Date())
-            ),
-            list(
-              extend = "excel",
-              title = paste0("PP_Dataset", "_", Sys.Date())
-            )
+  output$pp_dataset <- DT::renderDataTable({
+    DT::datatable(
+      data = CDISC$pp,
+      rownames = FALSE,
+      extensions = c("FixedHeader", "Buttons"),
+      options = list(
+        scrollX = TRUE,
+        scrollY = TRUE,
+        searching = TRUE,
+        fixedColumns = TRUE,
+        fixedHeader = TRUE,
+        autoWidth = TRUE,
+        dom = "Bfrtip",
+        buttons = list(
+          list(
+            extend = "copy",
+            title = paste0("PP_Dataset", "_", Sys.Date())
+          ),
+          list(
+            extend = "csv",
+            title = paste0("PP_Dataset", "_", Sys.Date())
+          ),
+          list(
+            extend = "excel",
+            title = paste0("PP_Dataset", "_", Sys.Date())
           )
         )
       )
-    }, server = FALSE)
+    )
+  }, server = FALSE)
 
-    output$adpp_dataset <- DT::renderDataTable({
-      DT::datatable(
-        data = CDISC$adpp,
-        extensions = c("FixedHeader", "Buttons"),
-        options = list(
-          scrollX = TRUE,
-          scrollY = TRUE,
-          lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
-          fixedHeader = TRUE,
-          dom = "Bfrtip",
-          buttons = c("copy", "csv", "excel")
-        )
+  output$adpp_dataset <- DT::renderDataTable({
+    DT::datatable(
+      data = CDISC$adpp,
+      extensions = c("FixedHeader", "Buttons"),
+      options = list(
+        scrollX = TRUE,
+        scrollY = TRUE,
+        lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
+        fixedHeader = TRUE,
+        dom = "Bfrtip",
+        buttons = c("copy", "csv", "excel")
       )
-    })
+    )
   })
+})
 
 # EXPORT Report ----------------------------------------------------------------
 

--- a/inst/shiny/tabs/outputs.R
+++ b/inst/shiny/tabs/outputs.R
@@ -458,7 +458,20 @@ observeEvent(res_nca(), {
         lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
         fixedHeader = TRUE,
         dom = "Bfrtip",
-        buttons = c("copy", "csv", "excel")
+        buttons = list(
+          list(
+            extend = "copy",
+            title = paste0("ADPP_Dataset", "_", Sys.Date())
+          ),
+          list(
+            extend = "csv",
+            title = paste0("ADPP_Dataset", "_", Sys.Date())
+          ),
+          list(
+            extend = "excel",
+            title = paste0("ADPP_Dataset", "_", Sys.Date())
+          )
+        )
       )
     )
   })

--- a/inst/shiny/tabs/outputs.R
+++ b/inst/shiny/tabs/outputs.R
@@ -411,28 +411,59 @@ output$boxplot <- renderPlotly({
   )
 })
 
-# CDISC ------------------------------------------------------------------------
+# Parameter datasets ------------------------------------------------------------------------
 
-# export pp and adpp as zip file
-output$exportCDISC <- downloadHandler(
-  filename = function() {
-    paste("CDISC_", Sys.Date(), ".zip", sep = "")
-  },
-  content = function(file) {
-    # Create a temporary directory to store the CSV files
-    temp_dir <- tempdir()
-
+# Create CDISC parameter datasets (PP, ADPP)
+  observeEvent(res_nca(), {
     CDISC <- export_cdisc(res_nca())
-    # Export the list of data frames to CSV files in the temporary directory
-    file_paths <- rio::export_list(
-      x = CDISC,
-      file = file.path(temp_dir, paste0(names(CDISC), "_", Sys.Date(), ".csv"))
-    )
 
-    # Create a ZIP file containing the CSV files
-    zip::zipr(zipfile = file, files = file_paths)
-  }
-)
+    output$pp_dataset <- DT::renderDataTable({
+      DT::datatable(
+        data = CDISC$pp,
+        rownames = FALSE,
+        extensions = c("FixedHeader", "Buttons"),
+        options = list(
+          scrollX = TRUE,
+          scrollY = TRUE,
+          searching = TRUE,
+          fixedColumns = TRUE,
+          fixedHeader = TRUE,
+          autoWidth = TRUE,
+          dom = "Bfrtip",
+          buttons = list(
+            list(
+              extend = "copy",
+              title = paste0("PP_Dataset", "_", Sys.Date())
+            ),
+            list(
+              extend = "csv",
+              title = paste0("PP_Dataset", "_", Sys.Date())
+            ),
+            list(
+              extend = "excel",
+              title = paste0("PP_Dataset", "_", Sys.Date())
+            )
+          )
+        )
+      )
+    }, server = FALSE)
+
+    output$adpp_dataset <- DT::renderDataTable({
+      DT::datatable(
+        data = CDISC$adpp,
+        extensions = c("FixedHeader", "Buttons"),
+        options = list(
+          scrollX = TRUE,
+          scrollY = TRUE,
+          lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
+          fixedHeader = TRUE,
+          dom = "Bfrtip",
+          buttons = c("copy", "csv", "excel")
+        )
+      )
+    })
+  })
+
 # EXPORT Report ----------------------------------------------------------------
 
 # ATTENTION: most of the blocks in the RMD are still eval = FALSE, as

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -304,15 +304,12 @@ fluidPage(
             )
           )
         ),
-        tabPanel("Parameter Datasets", 
+        tabPanel("Parameter Datasets",
                  tabsetPanel(
-                 tabPanel("PP",
-                          DTOutput("pp_dataset")
-                          ),
-                 tabPanel("ADPP",
-                          DTOutput("adpp_dataset")
-                          )
-                 #downloadButton("exportCDISC", "Export CDISC")
+                   tabPanel("PP",
+                            DTOutput("pp_dataset")),
+                   tabPanel("ADPP",
+                            DTOutput("adpp_dataset"))
                  )),
         tabPanel("Report",
           tabsetPanel(

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -304,7 +304,16 @@ fluidPage(
             )
           )
         ),
-        tabPanel("CDISC", downloadButton("exportCDISC", "Export CDISC")),
+        tabPanel("Parameter Datasets", 
+                 tabsetPanel(
+                 tabPanel("PP",
+                          DTOutput("pp_dataset")
+                          ),
+                 tabPanel("ADPP",
+                          DTOutput("adpp_dataset")
+                          )
+                 #downloadButton("exportCDISC", "Export CDISC")
+                 )),
         tabPanel("Report",
           tabsetPanel(
             tabPanel("Configuration",

--- a/man/pptestcd_dict.Rd
+++ b/man/pptestcd_dict.Rd
@@ -5,7 +5,7 @@
 \alias{pptestcd_dict}
 \title{Export CDISC Data}
 \format{
-An object of class \code{character} of length 18.
+An object of class \code{character} of length 31.
 }
 \usage{
 pptestcd_dict


### PR DESCRIPTION
## Issue

Closes #66

## Description

Renaming the tab from "CDISC" to "PP/ADPP"
Showing an in-app-display of the datasets in the tab
Renaming the download button from "Export CDISC" to "Download PP/ADPP" (I ended up with `Parameter datasets`)

## Definition of Done and how to test
- [x] After running NCA is easy to identify where to find PP/ADPP files
 - [x] You can download each file
 - [ ] File formats seem correct

## How to test
`NCA > Choose the analyte > Submit > Settings > Choose the Dose Number > Run NCA > See Outputs > Parameter datasets`

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
