### PR TITLE
Bug: Disallow user to check NCA / Outputs tabs without mapping data

### DIFF
--- a/inst/shiny/modules/column_mapping.R
+++ b/inst/shiny/modules/column_mapping.R
@@ -277,6 +277,11 @@ column_mapping_server <- function(id, data, manual_units, on_submit) {
     observeEvent(input$submit_columns, {
       Sys.sleep(1) # Make this artificially slow to show the loading spinner
 
+      # Enable other tabs
+      shinyjs::enable(selector = "#page li a[data-value=nca]")
+      shinyjs::enable(selector = "#page li a[data-value=visualisation]")
+      shinyjs::enable(selector = "#page li a[data-value=tlgs]")
+
       req(data())
       dataset <- data()
 
@@ -348,6 +353,7 @@ column_mapping_server <- function(id, data, manual_units, on_submit) {
 
       # Execute the callback function to change the tab
       on_submit()
+
     })
 
     list(

--- a/inst/shiny/modules/column_mapping.R
+++ b/inst/shiny/modules/column_mapping.R
@@ -279,7 +279,7 @@ column_mapping_server <- function(id, data, manual_units, on_submit) {
 
       # Enable other tabs
       purrr::walk(c("nca", "visualisation", "tlg"), \(tab) {
-        shinyjs::disable(selector = paste0("#page li a[data-value=", tab, "]"))
+        shinyjs::enable(selector = paste0("#page li a[data-value=", tab, "]"))
       })
 
       req(data())

--- a/inst/shiny/modules/column_mapping.R
+++ b/inst/shiny/modules/column_mapping.R
@@ -278,9 +278,9 @@ column_mapping_server <- function(id, data, manual_units, on_submit) {
       Sys.sleep(1) # Make this artificially slow to show the loading spinner
 
       # Enable other tabs
-      shinyjs::enable(selector = "#page li a[data-value=nca]")
-      shinyjs::enable(selector = "#page li a[data-value=visualisation]")
-      shinyjs::enable(selector = "#page li a[data-value=tlgs]")
+      purrr::walk(c("nca", "visualisation", "tlg"), \(tab) {
+        shinyjs::disable(selector = paste0("#page li a[data-value=", tab, "]"))
+      })
 
       req(data())
       dataset <- data()

--- a/inst/shiny/modules/tab_data.R
+++ b/inst/shiny/modules/tab_data.R
@@ -119,7 +119,7 @@ tab_data_server <- function(id) {
       manual_units = manual_units,
       on_submit = change_to_review_tab
     )
-    
+
     output$reviewDataContent <- renderUI({
       if (!is.null(processed_data()) && nrow(processed_data()) > 0) {
         tagList(

--- a/inst/shiny/modules/tab_data.R
+++ b/inst/shiny/modules/tab_data.R
@@ -8,7 +8,7 @@ source(system.file("/shiny/modules/column_mapping.R", package = "aNCA"))
 
 tab_data_ui <- function(id) {
   ns <- NS(id)
-
+  
   navset_pill(
     id = ns("data_navset"),
     nav_panel("Raw Data Upload",
@@ -39,14 +39,13 @@ tab_data_ui <- function(id) {
       )
     ),
     nav_panel("Review Data",
-      "This is the data set that will be used for the analysis.
-      If you want to make any changes, please do so in the Mapping and Filters tab.",
-      reactableOutput(ns("data_processed")),
-      tags$script(HTML("
-        $(document).ready(function(){
-          $('[data-toggle=\"tooltip\"]').tooltip(); 
-        });
-      "))
+              id = ns("data_navset-review"),
+              uiOutput(ns("reviewDataContent")),
+              tags$script(HTML("
+              $(document).ready(function(){
+              $('[data-toggle=\"tooltip\"]').tooltip();
+              });
+                               "))
     )
   )
 
@@ -93,7 +92,7 @@ tab_data_server <- function(id) {
         height = "98vh"
       )
     })
-
+    
     # Column Mapping ----
 
     # Define the manual units for concentration, dose, and time in a format recognized by PKNCA
@@ -120,6 +119,20 @@ tab_data_server <- function(id) {
       manual_units = manual_units,
       on_submit = change_to_review_tab
     )
+    
+    output$reviewDataContent <- renderUI({
+      if (!is.null(processed_data()) && nrow(processed_data()) > 0) {
+        tagList(
+          "This is the data set that will be used for the analysis.
+          If you would like to make any changes please return to the 'Mapping and Filters' tab.",
+          reactableOutput(ns("data_processed"))
+        )
+      } else {
+        div(
+          "Please map your data in the 'Mapping and Filters' section before reviewing it."
+        )
+      }
+    })
 
     # Reactive value for the processed dataset
     processed_data <- column_mapping$processed_data

--- a/inst/shiny/modules/tab_data.R
+++ b/inst/shiny/modules/tab_data.R
@@ -39,14 +39,14 @@ tab_data_ui <- function(id) {
       )
     ),
     nav_panel("Review Data",
-              id = ns("data_navset-review"),
-              uiOutput(ns("reviewDataContent")),
-              tags$script(HTML("
-              $(document).ready(function(){
-              $('[data-toggle=\"tooltip\"]').tooltip();
-              });
-                               ")
-                          )
+      id = ns("data_navset-review"),
+      uiOutput(ns("reviewDataContent")),
+      tags$script(HTML("
+      $(document).ready(function(){
+      $('[data-toggle=\"tooltip\"]').tooltip();
+      });
+                    ")
+      )
     )
   )
 

--- a/inst/shiny/modules/tab_data.R
+++ b/inst/shiny/modules/tab_data.R
@@ -8,7 +8,7 @@ source(system.file("/shiny/modules/column_mapping.R", package = "aNCA"))
 
 tab_data_ui <- function(id) {
   ns <- NS(id)
-  
+
   navset_pill(
     id = ns("data_navset"),
     nav_panel("Raw Data Upload",
@@ -45,7 +45,8 @@ tab_data_ui <- function(id) {
               $(document).ready(function(){
               $('[data-toggle=\"tooltip\"]').tooltip();
               });
-                               "))
+                               ")
+                          )
     )
   )
 
@@ -92,7 +93,7 @@ tab_data_server <- function(id) {
         height = "98vh"
       )
     })
-    
+
     # Column Mapping ----
 
     # Define the manual units for concentration, dose, and time in a format recognized by PKNCA

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -6,7 +6,7 @@ function(input, output, session) {
   # Initially disable all tabs except the 'Data' tab
   shinyjs::disable(selector = "#page li a[data-value=nca]")
   shinyjs::disable(selector = "#page li a[data-value=visualisation]")
-  shinyjs::disable(selector = "#page li a[data-value=tlgs]")
+  shinyjs::disable(selector = "#page li a[data-value=tlg]")
 
   # DATA ----
   data_module <- tab_data_server("data")

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -3,6 +3,11 @@
 function(input, output, session) {
   log_info("Startup")
 
+  # Initially disable all tabs except the 'Data' tab
+  shinyjs::disable(selector = "#page li a[data-value=nca]")
+  shinyjs::disable(selector = "#page li a[data-value=visualisation]")
+  shinyjs::disable(selector = "#page li a[data-value=tlgs]")
+  
   # DATA ----
   data_module <- tab_data_server("data")
   # Data set for analysis

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -7,7 +7,7 @@ function(input, output, session) {
   shinyjs::disable(selector = "#page li a[data-value=nca]")
   shinyjs::disable(selector = "#page li a[data-value=visualisation]")
   shinyjs::disable(selector = "#page li a[data-value=tlgs]")
-  
+
   # DATA ----
   data_module <- tab_data_server("data")
   # Data set for analysis

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -227,7 +227,7 @@ fluidPage(
       tab_visuals_ui("visuals")
     ),
     # New TLG tab
-    nav_panel("TLG", value = "tlgs",
+    nav_panel("TLG", value = "tlg",
       tab_tlg_ui("tlg")
     )
   ),

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -23,11 +23,12 @@ fluidPage(
     # DATA ----
     nav_panel(
       "Data",
+      value = "data",
       fluid = TRUE,
       tab_data_ui("data")
     ),
     # NCA ----
-    nav_panel("NCA", fluid = TRUE,
+    nav_panel("NCA", value = "nca", fluid = TRUE,
       fluidPage(
         actionButton("nca", "Run NCA", class = "run-nca-btn"),
 
@@ -221,12 +222,12 @@ fluidPage(
     ),
 
     # VISUALISATION ----
-    nav_panel("Visualisation",
+    nav_panel("Visualisation", value = "visualisation",
       fluid = TRUE,
       tab_visuals_ui("visuals")
     ),
     # New TLG tab
-    nav_panel("TLG",
+    nav_panel("TLG", value = "tlgs",
       tab_tlg_ui("tlg")
     )
   ),


### PR DESCRIPTION
## Issue

Closes #143 

## Description

When user has not mapped the data (define column names and accepted) it should not be able to go through other tabs (NCA or Outputs) as it can be confusing for them to see errror messages afterwards. Instead, those tabs should remain disable and perhpaps even show a notification

## Definition of Done

- [x] User cannot use other tabs until data is mapped
- [x] Once data is mapped, other tabs are enables
