### PR TITLE
Enhancement: Automatic selection of grouping vars

### DIFF
--- a/inst/shiny/functions/mapping_selectize_inputs.R
+++ b/inst/shiny/functions/mapping_selectize_inputs.R
@@ -34,8 +34,6 @@ update_selectize_inputs <- function(session, input_ids, column_names, manual_uni
       # For other columns, use basic logic
       selected_values <- if (column_name %in% column_names) column_name else NULL
     }
-    print(paste("Updating input:", input_id))
-    print(paste("Selected values:", paste(selected_values, collapse = ", ")))
     # Update the Selectize input with the new choices and selected values
     updateSelectizeInput(
       session,

--- a/inst/shiny/functions/mapping_selectize_inputs.R
+++ b/inst/shiny/functions/mapping_selectize_inputs.R
@@ -13,12 +13,35 @@
 #' @return None. This function updates the selectize inputs in the Shiny session.
 
 update_selectize_inputs <- function(session, input_ids, column_names, manual_units, desired_order) {
+
+  # Define the desired columns for Grouping_Variables
+  desired_grouping_columns <- c("TRTA", "TRTAN", "ACTARM", "TRT01A",
+                                "TRT01P", "AGE", "RACE", "SEX", "GROUP")
+
   for (input_id in input_ids) {
+    # Remove the "select_" prefix to get the actual column name
     column_name <- sub("select_", "", input_id)
-    selected_value <- if (column_name %in% column_names) column_name else NULL
+    # Determine the selected value(s) based on the column name
+    if (column_name == "Grouping_Variables") {
+      # Find which desired grouping columns are present
+      selected_values <- intersect(desired_grouping_columns, column_names)
+
+      # If none are present, set to NULL
+      if (length(selected_values) == 0) {
+        selected_values <- NULL
+      }
+    } else {
+      # For other columns, use basic logic
+      selected_values <- if (column_name %in% column_names) column_name else NULL
+    }
+    print(paste("Updating input:", input_id))
+    print(paste("Selected values:", paste(selected_values, collapse = ", ")))
+    # Update the Selectize input with the new choices and selected values
     updateSelectizeInput(
-      session, input_id, choices = c("Select Column" = "", column_names),
-      selected = selected_value
+      session,
+      input_id,
+      choices = c("Select Column" = "", column_names),
+      selected = selected_values
     )
   }
 
@@ -42,13 +65,9 @@ update_selectize_inputs <- function(session, input_ids, column_names, manual_uni
     updateSelectizeInput(
       session, input_id,
       choices = special_cases[[input_id]],
-      selected = if (sub("select_", "", input_id)
-                     %in% column_names) sub("select_", "", input_id) else NULL
+      selected =
+        if (sub("select_", "", input_id) %in% column_names)
+          sub("select_", "", input_id) else NULL
     )
   }
-
-  updateSelectizeInput(
-    session, "select_Grouping_Variables",
-    choices = setdiff(column_names, desired_order)
-  )
 }

--- a/inst/shiny/modules/column_mapping.R
+++ b/inst/shiny/modules/column_mapping.R
@@ -75,7 +75,7 @@ column_mapping_ui <- function(id) {
         tooltip(
           selectizeInput(
             ns("select_Grouping_Variables"),
-            "Grouping_Variables",
+            "Grouping Variables",
             choices = NULL,
             multiple = TRUE,
             options = list(placeholder = "Select Column(s)")

--- a/inst/shiny/modules/column_mapping.R
+++ b/inst/shiny/modules/column_mapping.R
@@ -75,7 +75,7 @@ column_mapping_ui <- function(id) {
         tooltip(
           selectizeInput(
             ns("select_Grouping_Variables"),
-            "Grouping Variables",
+            "Grouping_Variables",
             choices = NULL,
             multiple = TRUE,
             options = list(placeholder = "Select Column(s)")
@@ -243,7 +243,7 @@ column_mapping_server <- function(id, data, manual_units, on_submit) {
 
     # Define the required columns and group them into categories
     column_groups <- list(
-      "Group Identifiers" = c("STUDYID", "USUBJID", "Grouping Variables"),
+      "Group Identifiers" = c("STUDYID", "USUBJID", "Grouping_Variables"),
       "Sample Variables" = c("ANALYTE", "PCSPEC", "ROUTE", "AVAL"),
       "Dose Variables" = c("DOSNO", "DOSEA", "ADOSEDUR"),
       "Time Variables" = c("AFRLT", "ARRLT", "NFRLT", "NRRLT"),
@@ -299,12 +299,12 @@ column_mapping_server <- function(id, data, manual_units, on_submit) {
         return()
       }
 
-      # Extract and store the "Grouping Variables" column
+      # Extract and store the "Grouping_Variables" column
       grouping_variables(input$select_Grouping_Variables)
 
-      # Remove "Grouping Variables" from selected columns to prevent renaming
+      # Remove "Grouping_Variables" from selected columns to prevent renaming
       selected_cols[["Group Identifiers"]] <- selected_cols[["Group Identifiers"]][
-        names(selected_cols[["Group Identifiers"]]) != "Grouping Variables"
+        names(selected_cols[["Group Identifiers"]]) != "Grouping_Variables"
       ]
 
       # Rename columns

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -7,7 +7,7 @@ function(input, output, session) {
   data_module <- tab_data_server("data")
   # Data set for analysis
   data <- data_module$data
-  # Grouping_Variables
+  # Grouping Variables
   grouping_vars <- data_module$grouping_variables
   # NCA ----
   source(system.file("shiny/tabs/nca.R", package = "aNCA"), local = TRUE)

--- a/inst/shiny/server.R
+++ b/inst/shiny/server.R
@@ -7,7 +7,7 @@ function(input, output, session) {
   data_module <- tab_data_server("data")
   # Data set for analysis
   data <- data_module$data
-  # Grouping Variables
+  # Grouping_Variables
   grouping_vars <- data_module$grouping_variables
   # NCA ----
   source(system.file("shiny/tabs/nca.R", package = "aNCA"), local = TRUE)


### PR DESCRIPTION
## Issue

Closes #154 

## Description
For column mapping at the moment, grouping variables are selected manually by the user. However it would be useful if some columns are automatically selected if they are present in the data.

Main columns used for grouping:
TRTA
TRTAN
ACTARM
TRT01A
TRT01P
AGE
RACE
SEX
For pre-clinical: GROUP

## Definition of Done

The requirements for the feature to be complete:
- [x] Automatic selection of above columns in the 'Grouping Variables' selectInput in the Mapping section.
- [x] If the columns are not present, input box still works as normal and columns can be manually selected
- [x] If some but not all of the columns are present, the ones included should be automatically selected with no issues.

## How to test

Mapping and Filters section -> Grouping Variables

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
