### PR TITLE
Introduce instructions on package versioning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@ How to test features not covered by unit tests.
 - [ ] Code passes all unit tests
 - [ ] New logic covered by unit tests
 - [ ] New logic is documented
+- [ ] Package version is incremented
 
 ## Notes to reviewer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,14 +60,24 @@ This part is here as a reminder to perform basic tasks and checks before the cod
 - Code passes all unit tests
 - New logic covered is by unit tests
 - New logic is documented
+- Package version is bumped
 
 The above rules will help keep our work organized, as well as allow for quick information flow between related issues, branches and pull requests.
 
 #### Notes to reviewer
 If there is anything that the reviewer should know before tackling the pull request, please provide it here. This could include things like pointing to specific parts of the code that require special attention, explaining decisions behind unusual implementations or providing logic behind changing the scope of the task.
 
+### Bumping package version
+Package versioning must use the semantic versioning schema, with developement extension: **X.Y.Z.9NNN**
+
+#### Developement version
+In each PR that introduces changes to the code, dependencies or the function documentation, it is required that the developement package version is incremented by 1 (this is the .9NNN number, the last part of the versioning schema). As the current feature branch might be outdated, before merging please cross-check with the **main** branch that the version you are submitting is correct.
+
+#### Semantic versioning
+The versioning schema for major / minor / patch releases must adhere to [semantic versioning](https://semver.org/) guidelines.
+
 ## Code review
-Each pull request must be accepted by at least one reviewer before it can be merged to the main branch.
+Each pull request must be accepted by at least two reviewers before it can be merged to the main branch.
 
 #### For reviewee
 When the change is done, pull request is open and the description is filled, please move your issue from **In Progress** to **Needs review** status, so it can be picked up by a reviewer. From this point it is up to the contributor and the person validating the change to work out any kinks and lead to merging the changes.


### PR DESCRIPTION
Hi everyone,

with rapid development of the package, we are just few critical features and fixes away from having a stable version of the package, which could be published on CRAN. With that, I believe it would be beneficial to introduce **instructions** and **requirements** on package versioning. Proper, semantic versioning is not an important issue at this point, but since #172 added the possibility of installing the package with `pak`, tracking changes in the development version will be beneficial.

Therefore, I would like to suggest adding the **requirement** of bumping the package version in `DESCRIPTION` file, in all PRs which introduce code changes, before merging. We could go with just incrementing the last, .9000 part of the version, as long as we wish, and then when we believe the package is ready for publication, start off with version 0.1.0.

**This pull request** introduces two changes:
- Adds information on package version bumping to the `CONTRIBUTING.md` file
- Adds *Package version is incremented* to the checklist in the pull request template.

Please let me know what you think of introducing this at this point in time, feedback welcome. I think this will get everyone in the team in the healthy habit of incrementing the package version, in preparation of maintaining the _officialy released_ application.