### PR TITLE
Documentation: Add workflow for automatic page deployment

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,0 +1,47 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+on:
+  push:
+    branches: main
+  pull_request:
+    branches: main
+  workflow_dispatch:
+
+name: Deploy website
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, dest_dir = "page")
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: page

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,3 +75,4 @@ Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Language: en-US
+URL: https://pharmaverse.github.io/aNCA/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,3 @@
+template:
+  bootstrap: 5
+url: "https://pharmaverse.github.io/aNCA/"


### PR DESCRIPTION
## Issue

Closes #74 

## Description

I have noticed our page did not have a proper workflow set up to automatically update and redeploy. The issue seemed stale, so I have picked it up and added github workflow do do exactly that.

As a follow-up, I would propose taking a look at #75 and migrating the current PDF guide to a vignette/article, so that we can build upon it in a proper fashion.

Let me know what you think! 