### PR TITLE
Refactor: deload updating mydata from slope selector

### DIFF
--- a/inst/shiny/global.R
+++ b/inst/shiny/global.R
@@ -1,16 +1,13 @@
 source("modules/tab_data.R")
-#Load labels
-LABELS <- read.csv(system.file("shiny/data/adnca_labels.csv", package = "aNCA"))
-
 source("modules/slope_selector.R")
-
 source("modules/units_table.R")
+source("modules/tlg_plot.R")
+source("modules/tab_visuals.R")
+source("modules/slope_rules.R")
 
 source("functions/partial_auc_input.R")
-
-source("modules/tlg_plot.R")
-
-source("modules/tab_visuals.R")
-
 source("functions/mapping_selectize_inputs.R")
 source("functions/generate_col_defs.R")
+
+#Load labels
+LABELS <- read.csv(system.file("shiny/data/adnca_labels.csv", package = "aNCA"))

--- a/inst/shiny/modules/slope_rules.R
+++ b/inst/shiny/modules/slope_rules.R
@@ -1,0 +1,16 @@
+slope_rules_ui <- function(id) {
+  ns <- NS(id)
+
+  reactableOutput(ns("slope_rules_table"))
+}
+
+slope_rules_server <- function(id, slope_rules, update_trigger) {
+  moduleServer(id, function(input, output, session) {
+    output$slope_rules_table <- renderReactable({
+      reactable(slope_rules())
+    }) |>
+      bindEvent(update_trigger())
+
+    outputOptions(output, "slope_rules_table", suspendWhenHidden = FALSE)
+  })
+}

--- a/inst/shiny/modules/slope_selector.R
+++ b/inst/shiny/modules/slope_selector.R
@@ -9,7 +9,6 @@ slope_selector_ui <- function(id) {
       # Selection and exclusion controls #
       actionButton(ns("add_rule"), "+ Exclusion/Selection", class = "btn-success"),
       actionButton(ns("remove_rule"), "- Remove selected rows", class = "btn-warning"),
-      actionButton(ns("save_ruleset"), tags$b("Apply"), class = "btn-primary"),
       # Help widget #
       dropdown(
         div(
@@ -96,8 +95,7 @@ slope_selector_ui <- function(id) {
 
 slope_selector_server <- function(
   id, mydata, res_nca, profiles_per_patient,
-  cycle_nca, analyte_nca, pcspec_nca,
-  pk_nca_trigger, settings_upload
+  cycle_nca, analyte_nca, pcspec_nca, settings_upload
 ) {
   moduleServer(id, function(input, output, session) {
     log_trace("{id}: Attaching server")
@@ -369,17 +367,6 @@ slope_selector_server <- function(
         edited_slopes[edit$row, edit$column] <- edit$value
         manual_slopes(edited_slopes)
       })
-    })
-
-    # Observe input$nca
-    observeEvent(profiles_per_patient(), {
-      mydata(filter_slopes(mydata(), manual_slopes(), profiles_per_patient()))
-    })
-
-    #' saves and implements provided ruleset
-    observeEvent(input$save_ruleset, {
-      mydata(filter_slopes(mydata(), manual_slopes(), profiles_per_patient()))
-      pk_nca_trigger(pk_nca_trigger() + 1)
     })
 
     #' Plot data is a local reactive copy of full data. The purpose is to display data that

--- a/inst/shiny/ui.R
+++ b/inst/shiny/ui.R
@@ -239,10 +239,7 @@ fluidPage(
                 "Slopes",
                 DTOutput("preslopesettings")
               ),
-              tabPanel(
-                "Exclusions",
-                tableOutput("manual_slopes2")
-              ),
+              tabPanel("Slope rules", slope_rules_ui("slope_rules")),
               tabPanel("Parameter Datasets",
                        tabsetPanel(
                          tabPanel("PP",


### PR DESCRIPTION
TODO: I have messed up with the base branch, update base when #184 is merged
TODO: Wait on #177 to be merged

## Issue

Addresses #121, #144 

## Description

- Updates `slope_selector` so that it no longer updates `mydata` object. Apply button has been removed. Instead, the user should click on `Run NCA` in order to update the results, which is handled by `nca.R`.
- Adds warning stating that settings has been changed and the analysis must be re-run.
- In addition, table for viewing active selections/exclusions has been modularized and only updates when results have been recalculated.

## How to test

TBA

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] Package version is incremented

## Notes to reviewer

TBA
