### PR TITLE
bug: start and end time inconsistent and duplicates missing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9010
+Version: 0.0.0.9011
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/R/lambda_slope_plot.R
+++ b/R/lambda_slope_plot.R
@@ -72,11 +72,11 @@ lambda_slope_plot <- function(
       if_all(all_of(column_names), ~ .x == row_values[[deparse(substitute(.x))]]),
       !exclude_half.life,
       TIME >= sum(
-          subset(
-            lambda_res,
-            lambda_res$PPTESTCD == "lambda.z.time.first",
-            select = c("start", "PPSTRES")
-          )
+        subset(
+          lambda_res,
+          lambda_res$PPTESTCD == "lambda.z.time.first",
+          select = c("start", "PPSTRES")
+        )
       )
     ) %>%
     arrange(IX) %>%

--- a/R/lambda_slope_plot.R
+++ b/R/lambda_slope_plot.R
@@ -58,7 +58,7 @@ lambda_slope_plot <- function(
   #Obtain values for slopes selection
   lambda_res <- myres$result %>%
     filter(if_all(all_of(column_names), ~ .x == row_values[[deparse(substitute(.x))]])) %>%
-    arrange(across(all_of(column_names)), start, desc(end)) %>%
+    arrange(across(all_of(column_names)), start_dose, desc(end_dose)) %>%
     filter(!duplicated(paste0(!!!rlang::syms(column_names), PPTESTCD)))
 
   lambda_z_n_points <- as.numeric(lambda_res$PPSTRES[lambda_res$PPTESTCD == "lambda.z.n.points"])
@@ -68,19 +68,15 @@ lambda_slope_plot <- function(
 
   lambda_z_ix_rows <- conc_pknca_df %>%
     ungroup() %>%
-    mutate(ARRLT = round(ARRLT, 3)) %>%
     filter(
       if_all(all_of(column_names), ~ .x == row_values[[deparse(substitute(.x))]]),
       !exclude_half.life,
-      ARRLT >= round(
-        sum(
+      TIME >= sum(
           subset(
             lambda_res,
             lambda_res$PPTESTCD == "lambda.z.time.first",
             select = c("start", "PPSTRES")
           )
-        ),
-        3
       )
     ) %>%
     arrange(IX) %>%
@@ -158,7 +154,7 @@ lambda_slope_plot <- function(
 
   #Create initial plot
   p <- plot_data %>%
-    ggplot(aes(x = TIME, y = AVAL)) +
+    ggplot(aes(x = ARRLT, y = AVAL)) +
     geom_line(color = "gray70", linetype = "solid", linewidth = 1) +
     geom_smooth(
       data = subset(plot_data, IX_color == "hl.included"),
@@ -235,11 +231,11 @@ lambda_slope_plot <- function(
   pl <- pl %>%
     add_trace(
       plot_data,
-      x = ~TIME, y = ~log10(AVAL),
+      x = ~ARRLT, y = ~log10(AVAL),
       customdata = customdata,
       text = ~paste0(
         "Data Point: ", IX, "\n",
-        "(", round(TIME, 0), " , ", signif(AVAL, 3), ")"
+        "(", round(ARRLT, 1), " , ", signif(AVAL, 3), ")"
       ),
       type = "scatter",
       mode = "markers",
@@ -249,7 +245,7 @@ lambda_slope_plot <- function(
         plot_data$is.excluded.hl ~ "red",
         plot_data$IX %in% lambda_z_ix_rows$IX ~ "green",
         TRUE ~ "black"
-      ), size = 15, opacity = 0), # Make points semi-transparent
+      ), size = 12, opacity = 0), # Make points semi-transparent
       showlegend = FALSE
     )
 

--- a/R/pivot_wider_pknca_results.R
+++ b/R/pivot_wider_pknca_results.R
@@ -26,10 +26,12 @@ pivot_wider_pknca_results <- function(myres) {
     pull(PPSTRESU, PPTESTCD)
 
   # Create duplicates for accurate lambda.z.ix calculation
-  data_with_duplicates <- dose_profile_duplicates(myres$data$conc$data,
-                                                  c(unlist(unname(myres$data$conc$columns$groups)),
-                                                  "DOSNO"))
-  
+  data_with_duplicates <- dose_profile_duplicates(
+    myres$data$conc$data,
+    c(unlist(unname(myres$data$conc$columns$groups)),
+      "DOSNO")
+  )
+
   # Filter out infinite AUCs and pivot the data to incorporate
   # the parameters into columns with their units
   infinite_aucs_vals <- myres$result %>%

--- a/R/pivot_wider_pknca_results.R
+++ b/R/pivot_wider_pknca_results.R
@@ -52,7 +52,7 @@ pivot_wider_pknca_results <- function(myres) {
     # filter out the rows that do not have relation with lambda calculation (when calculated)
     # and derive the IX
     filter(!exclude_half.life | is.na(lambda.z.time.first) | is.na(lambda.z.n.points)) %>%
-    filter(TIME >= (lambda.z.time.first + start) | is.na(lambda.z.time.first)) %>%
+    filter(ARRLT >= (lambda.z.time.first + start) | is.na(lambda.z.time.first)) %>%
     filter(row_number() <= lambda.z.n.points | is.na(lambda.z.n.points)) %>%
     mutate(lambda.z.ix = paste0(IX, collapse = ",")) %>%
     mutate(lambda.z.ix = ifelse(is.na(lambda.z), NA, lambda.z.ix)) %>%

--- a/R/pivot_wider_pknca_results.R
+++ b/R/pivot_wider_pknca_results.R
@@ -25,6 +25,11 @@ pivot_wider_pknca_results <- function(myres) {
     distinct() %>%
     pull(PPSTRESU, PPTESTCD)
 
+  # Create duplicates for accurate lambda.z.ix calculation
+  data_with_duplicates <- dose_profile_duplicates(myres$data$conc$data,
+                                                  c(unlist(unname(myres$data$conc$columns$groups)),
+                                                  "DOSNO"))
+  
   # Filter out infinite AUCs and pivot the data to incorporate
   # the parameters into columns with their units
   infinite_aucs_vals <- myres$result %>%
@@ -41,7 +46,7 @@ pivot_wider_pknca_results <- function(myres) {
 
   infinite_aucs <- inner_join(infinite_aucs_vals, infinite_aucs_exclude)
 
-  infinite_aucs_with_lambda <- inner_join(myres$data$conc$data, infinite_aucs) %>%
+  infinite_aucs_with_lambda <- inner_join(data_with_duplicates, infinite_aucs) %>%
     group_by(STUDYID, PCSPEC, ANALYTE, USUBJID, DOSNO) %>%
     arrange(STUDYID, PCSPEC, ANALYTE, USUBJID, DOSNO, IX) %>%
     # Deduce if the user perform an exclusion/selection to indicate if the slope
@@ -52,7 +57,7 @@ pivot_wider_pknca_results <- function(myres) {
     # filter out the rows that do not have relation with lambda calculation (when calculated)
     # and derive the IX
     filter(!exclude_half.life | is.na(lambda.z.time.first) | is.na(lambda.z.n.points)) %>%
-    filter(ARRLT >= (lambda.z.time.first + start) | is.na(lambda.z.time.first)) %>%
+    filter(TIME >= (lambda.z.time.first + start) | is.na(lambda.z.time.first)) %>%
     filter(row_number() <= lambda.z.n.points | is.na(lambda.z.n.points)) %>%
     mutate(lambda.z.ix = paste0(IX, collapse = ",")) %>%
     mutate(lambda.z.ix = ifelse(is.na(lambda.z), NA, lambda.z.ix)) %>%
@@ -65,7 +70,7 @@ pivot_wider_pknca_results <- function(myres) {
     interval_aucs_vals <- myres$result %>%
       filter(type_interval == "manual", startsWith(PPTESTCD, "aucint")) %>%
       mutate(
-        interval_name = paste0(signif(start), "-", signif(end)),
+        interval_name = paste0(signif(start_dose), "-", signif(end_dose)),
         interval_name_col = paste0(PPTESTCD, "_", interval_name)
       ) %>%
       select(-exclude, -PPSTRESU, -PPORRES, -PPORRESU, -start, -end,
@@ -76,10 +81,10 @@ pivot_wider_pknca_results <- function(myres) {
     interval_aucs_exclude <- myres$result %>%
       filter(type_interval == "manual", startsWith(PPTESTCD, "aucint")) %>%
       mutate(
-        interval_name = paste0(signif(start), "-", signif(end)),
+        interval_name = paste0(signif(start_dose), "-", signif(end_dose)),
         interval_name_col = paste0("exclude.", PPTESTCD, "_", interval_name)
       ) %>%
-      select(-PPSTRES, -PPSTRESU, -PPORRES, -PPORRESU, -start, -end,
+      select(-PPSTRES, -PPSTRESU, -PPORRES, -PPORRESU, -start, -end, start_dose, end_dose,
              -PPTESTCD, -interval_name, -type_interval) %>%
       pivot_wider(names_from = interval_name_col, values_from = exclude)
 
@@ -99,7 +104,7 @@ pivot_wider_pknca_results <- function(myres) {
   # Do a final standardization of the results reshaped
   all_aucs  %>%
     mutate(Exclude = pmap_chr(across(starts_with("exclude.")), .extract_exclude_values)) %>%
-    select(-starts_with("exclude.")) %>%
+    select(-starts_with("exclude."), -start_dose, -end_dose) %>%
     # Define the number of decimals to round the results
     mutate(across(where(is.numeric), ~ round(.x, 3)))  %>%
     ungroup()

--- a/inst/shiny/modules/nca_results.R
+++ b/inst/shiny/modules/nca_results.R
@@ -27,7 +27,7 @@ nca_results_server <- function(id, res_nca, rules, grouping_vars) {
       req(res_nca())
       # Transform results
       final_results <- pivot_wider_pknca_results(res_nca())
-      
+
       # Apply rules
       for (rule_input in grep("^rule_", names(rules), value = TRUE)) {
         if (!rules[[rule_input]]) next

--- a/inst/shiny/modules/nca_results.R
+++ b/inst/shiny/modules/nca_results.R
@@ -27,7 +27,7 @@ nca_results_server <- function(id, res_nca, rules, grouping_vars) {
       req(res_nca())
       # Transform results
       final_results <- pivot_wider_pknca_results(res_nca())
-
+      
       # Apply rules
       for (rule_input in grep("^rule_", names(rules), value = TRUE)) {
         if (!rules[[rule_input]]) next

--- a/inst/shiny/modules/tab_nca.R
+++ b/inst/shiny/modules/tab_nca.R
@@ -142,9 +142,9 @@ tab_nca_server <- function(id, data, grouping_vars) {
           myres$result <- myres$result %>%
             inner_join(select(mydata()$dose$data, -exclude,
                               -mydata()$conc$columns$groups$group_analyte)) %>%
-            mutate(start = start - !!sym(mydata()$dose$columns$time), #mutate to time from MRD
-                   end = end - !!sym(mydata()$dose$columns$time)) %>%
-            select(names(myres$result))
+            mutate(start_dose = start - !!sym(myres$data$dose$columns$time),
+                   end_dose = end - !!sym(myres$data$dose$columns$time)) %>%
+            select(names(myres$result), start_dose, end_dose)
 
           res_nca(myres)
           updateTabsetPanel(session, "ncapanel", selected = "Results")

--- a/inst/shiny/modules/tab_nca.R
+++ b/inst/shiny/modules/tab_nca.R
@@ -142,7 +142,7 @@ tab_nca_server <- function(id, data, grouping_vars) {
           myres$result <- myres$result %>%
             inner_join(select(mydata()$dose$data, -exclude,
                               -mydata()$conc$columns$groups$group_analyte)) %>%
-            mutate(start = start - !!sym(mydata()$dose$columns$time),
+            mutate(start = start - !!sym(mydata()$dose$columns$time), #mutate to time from MRD
                    end = end - !!sym(mydata()$dose$columns$time)) %>%
             select(names(myres$result))
 


### PR DESCRIPTION
## Issue

Closes #214 

## Description

During development, the derivation of start and end time has swapped occasionally between being the time from first dose, or the time from most recent dose. Due to this, there are some sections later on in the code that are inconsistent- ie some parts assume that it is time from first dose, and others that it is time from mrd. 
Lambda.z.ix is also not correct due to the start times and also the duplicates are missing.

## Definition of Done

- [x] start and end time used as correct time for calculations
- [x] Plots show the correct time, and lambda.z.ix correctly calculated

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] Package version is incremented

## Notes to reviewer

