### PR TITLE
Bug: Cmax in NCA Calculations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9010
+Version: 0.0.0.9011
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/R/pivot_wider_pknca_results.R
+++ b/R/pivot_wider_pknca_results.R
@@ -52,7 +52,7 @@ pivot_wider_pknca_results <- function(myres) {
     # filter out the rows that do not have relation with lambda calculation (when calculated)
     # and derive the IX
     filter(!exclude_half.life | is.na(lambda.z.time.first) | is.na(lambda.z.n.points)) %>%
-    filter(TIME >= (lambda.z.time.first + start) | is.na(lambda.z.time.first)) %>%
+    filter(ARRLT >= (lambda.z.time.first + start) | is.na(lambda.z.time.first)) %>%
     filter(row_number() <= lambda.z.n.points | is.na(lambda.z.n.points)) %>%
     mutate(lambda.z.ix = paste0(IX, collapse = ",")) %>%
     mutate(lambda.z.ix = ifelse(is.na(lambda.z), NA, lambda.z.ix)) %>%

--- a/inst/shiny/modules/nca_setup.R
+++ b/inst/shiny/modules/nca_setup.R
@@ -509,12 +509,9 @@ nca_setup_server <- function(id, data, mydata, res_nca) { # nolint : TODO: compl
 
       mydata$options <- list(
         auc.method = input$method,
-        allow.tmax.in.half.life = FALSE,
         keep_interval_cols = c("DOSNO", "type_interval"),
         # Make sure the standard options do not prohibit results
-        min.hl.r.squared = 0.001,
-        min.span.ratio = Inf,
-        min.hl.points = 3
+        min.hl.r.squared = 0.7
       )
 
       # Include main intervals as specified by the user

--- a/inst/shiny/modules/nca_setup.R
+++ b/inst/shiny/modules/nca_setup.R
@@ -511,7 +511,7 @@ nca_setup_server <- function(id, data, mydata, res_nca) { # nolint : TODO: compl
         auc.method = input$method,
         keep_interval_cols = c("DOSNO", "type_interval"),
         # Make sure the standard options do not prohibit results
-        min.hl.r.squared = 0.7
+        min.hl.r.squared = 0.01
       )
 
       # Include main intervals as specified by the user

--- a/inst/shiny/modules/nca_setup.R
+++ b/inst/shiny/modules/nca_setup.R
@@ -509,7 +509,7 @@ nca_setup_server <- function(id, data, mydata, res_nca) { # nolint : TODO: compl
 
       mydata$options <- list(
         auc.method = input$method,
-        allow.tmax.in.half.life = TRUE,
+        allow.tmax.in.half.life = FALSE,
         keep_interval_cols = c("DOSNO", "type_interval"),
         # Make sure the standard options do not prohibit results
         min.hl.r.squared = 0.001,


### PR DESCRIPTION
## Issue

Closes #148 

## Description

We would like that PKNCA's automatic behaviour does not include never automatically tmax for the half life calculation and that it takes 3 points always.

## Definition of Done

- [x] Tmax automatically excluded from half life calculation. and 3 points minimum
- [x] Manual slope selection overrides this setting

## How to test

Check that Tmax not included in automatic slopes
Add manual slopes- include Tmax, and only select 2 points.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] Package version is incremented

## Notes to reviewer
This was actually an easy fix, as the PKNCA options default settings are to exclude tmax and to have min 3 points in hl calculation. And if you don't explicitly write it (so remove from PKNCAoptions), then any manual slopes will override this for those subjects.

Important to note that if you are testing the Tmax, it wont show up in the plot (because of issue #121 ), so best to check the results and see if labda.z.ix has been updated, and lambda.z.time.first.

Also, the change to pivot_wider_pknca is just temporary, to ensure that lambda.z.ix was correct. This will be updated when #214 has been merged!