### PR TITLE
Enhancement: upon submiting tlg order, switch to first populated tab

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9016
+Version: 0.0.0.9018
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/inst/shiny/modules/tab_tlg.R
+++ b/inst/shiny/modules/tab_tlg.R
@@ -25,7 +25,7 @@ tab_tlg_ui <- function(id) {
       )
     ),
     nav_panel("Tables", "To be added"),
-    nav_panel("Listings", uiOutput(ns("lists"), class = "tlg-module"), value = "Lists"),
+    nav_panel("Listings", uiOutput(ns("listings"), class = "tlg-module"), value = "Listings"),
     nav_panel("Graphs", uiOutput(ns("graphs"), class = "tlg-module"), value = "Graphs"),
     # disable loader for initial empty UI render #
     footer = tags$style(HTML(paste0(".tlg-module .load-container {opacity: 0;}")))
@@ -211,10 +211,11 @@ tab_tlg_server <- function(id) {
     #' for mysterious reasons nav_select() and updateTabsetPanel() were not working,
     #' so solved this using JavaScript
     observeEvent(list(input$submit_tlg_order, input$submit_tlg_order_alt), ignoreInit = TRUE, {
+      tab_to_switch <- pull(tlg_order_filtered()[1, "Type"]) |> paste0("s")
       shinyjs::runjs(
         paste0("
           // change the tab to graphs //
-          $(`#", session$ns("tlg_tabs"), " a[data-value='Lists']`)[0].click();
+          $(`#", session$ns("tlg_tabs"), " a[data-value='", tab_to_switch, "']`)[0].click();
 
           // enable spinner, as it was disabled for initial empty UI render //
           setTimeout(function() {
@@ -262,14 +263,14 @@ tab_tlg_server <- function(id) {
       do.call(navset_pill_list, panels)
     })
 
-    output$lists <- renderUI({
+    output$listings <- renderUI({
       req(tlg_order_filtered())
 
-      tlg_order_lists <- filter(tlg_order_filtered(), Type == "Listing") %>%
+      tlg_order_listings <- filter(tlg_order_filtered(), Type == "Listing") %>%
         select("id") %>%
         pull()
 
-      panels <- lapply(tlg_order_lists, function(g_id) {
+      panels <- lapply(tlg_order_listings, function(g_id) {
         list_ui <- {
           g_def <- .TLG_DEFINITIONS[[g_id]]
           module_id <- paste0(g_id, stringi::stri_rand_strings(1, 5))


### PR DESCRIPTION
## Issue
Closes #252

## Description
Currently when the user submits an order, the tab switches automatically to Lists. The application should switch to the first populated tab - if no listings were selected, then it should switch to Graphs.

Implemented changes detect type of the first TLG from the order and switch to appropriate tab.

## Definition of Done
- [x] when submitting the order, tab is switched to the first populated one.

## How to test
Run the app, map the data, go to _TLG_ tab. When submitting an order with a _Listing_ TLG, the tab should be switched to _Listings_. When the _Listing_ is removed from the order, the tab should switch to _Graphs_ upon submitting.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Package version is incremented

## Notes to reviewer
In this version, the plots are bugged and not rendering properly - this is fixed in #251 