### PR TITLE
Fix: do not display list names in TLG listings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9016
+Version: 0.0.0.9017
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/inst/shiny/modules/tlg/tlg_module.R
+++ b/inst/shiny/modules/tlg/tlg_module.R
@@ -174,7 +174,7 @@ tlg_module_server <- function(id, type, render_list, options = NULL) {
       page_start <- page_end - entries_per_page() + 1
       if (page_end > num_plots) page_end <- num_plots
 
-      tlg_list()[page_start:page_end]
+      unname(tlg_list()[page_start:page_end])
     })
 
     #' resets the options to defaults


### PR DESCRIPTION
## Issue
Closes #228

## Description
Since we rely on `renderPrint` to display listings with original formatting, the output displays names of the elements, which looks ugly. This PR introduces changes that `unname()` the list of displayed TLGs in order to show index numbers instead of names.

## Definition of Done
- [x] List element name does not appear in the results of Listings TLGs.

## How to test
Run the app, map the data, go to TLGs tab, submit default order. Check if the Listings display includes index numbers instead of names.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] Package version is incremented