### PR TITLE
Enhancement: add tests utils-slope_selector (filter_slopes) - #287

### DIFF
--- a/tests/testthat/test-utils-slope_selector.R
+++ b/tests/testthat/test-utils-slope_selector.R
@@ -87,6 +87,13 @@ describe(".filter_slopes", {
       "^No reason provided for the following exclusions*"
     )
   })
+
+  it("should return data unchanged if no slopes are provided", {
+    res_null <- filter_slopes(DATA_FIXTURE, NULL, DOSNOS_FIXTURE, slope_groups)
+    res_empty <- filter_slopes(DATA_FIXTURE, data.frame(), DOSNOS_FIXTURE, slope_groups)
+    expect_equal(res_null, DATA_FIXTURE)
+    expect_equal(res_empty, DATA_FIXTURE)
+  })
 })
 
 EXISTING_FIXTURE <- data.frame(


### PR DESCRIPTION
Contributes to #287 

## Description
### Main implementation
* Added tests to `tests/testthat/test-utils-slope_selector.R` for 100% coverage (covr). Added test for filter_slopes

## Definition of Done

- [x] tests have a 100% coverage for `utils-slope_selector.R` (`covr`)
- [x] tests seem logical

## How to test
- check tests in file `tests/testthat/test-utils-slope_selector.R`