### PR TITLE
test: add test where one of the filters is NULL (apply_filters) - #287

### DIFF
--- a/tests/testthat/test-apply_filters.R
+++ b/tests/testthat/test-apply_filters.R
@@ -105,6 +105,19 @@ describe("apply_filters works correctly", {
     expect_equal(nrow(apply_filters(mtcars, filter)), 30)
   })
 
+  test_that("apply_filters skips NULL filters", {
+    filters_with_null <- list(
+      list(
+        column = "mpg",
+        condition = ">",
+        value = "21"
+      ),
+      NULL
+    )
+
+    expect_equal(nrow(apply_filters(mtcars, filters_with_null)), 12)
+  })
+
 })
 
 describe("apply_filters throws errors for invalid input", {


### PR DESCRIPTION
Contributes to #287 

## Description
### Main implementation
* Added tests to `tests/testthat/test-apply_filters.R` for 100% coverage (covr). Adds test for NULL filter in apply_filters.R

## Definition of Done
- [x] tests have a 100% coverage for `zzz.R` (`covr`)
- [x] tests seem logical

## How to test
- check tests in file `tests/testthat/test-apply_filters.R`

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
-  ~Package version is incremented~

