### PR TITLE
Chore: Run main workflow on merge with main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,6 @@ jobs:
   spellcheck:
     name: Spelling
     uses: ./.github/workflows/spellcheck.yml
-    if: github.event_name == 'pull_request'
     needs: get_r_version
     with:
       r-version: "${{ needs.get_r_version.outputs.r-version }}"
@@ -52,7 +51,6 @@ jobs:
     name: Lint
     uses: ./.github/workflows/lintr.yml
     needs: get_r_version
-    if: github.event_name == 'pull_request'
     with:
       r-version: "${{ needs.get_r_version.outputs.r-version }}"
 
@@ -60,7 +58,6 @@ jobs:
     name: Man Pages
     uses: ./.github/workflows/man-pages.yml
     needs: get_r_version
-    if: github.event_name == 'pull_request'
     with:
       r-version: "${{ needs.get_r_version.outputs.r-version }}"
     
@@ -68,13 +65,11 @@ jobs:
     name: Tests
     uses: ./.github/workflows/test.yml
     needs: get_r_version
-    if: github.event_name == 'pull_request'
     with:
       r-version: "${{ needs.get_r_version.outputs.r-version }}"
 
   check:
     name: Check
     uses: ./.github/workflows/r-cmd-check.yml
-    if: github.event_name == 'pull_request'
     with:
         error-on: note


### PR DESCRIPTION
I have noticed that we skip the main workflow on merges with `main` - the checks are only run on the feature branch during PR, but skipped on merge commit. This should make no substantial difference - we are usually merging main into feature branch before merging into main, so the checks run before the merge are performed on identical code as after merging. However, this means checks on merge commits are skipped and lead to a red cross with `failure` label on main branch. With this change, the checks will run again after merge, giving the main branch a green checkmark and additionally confirming that everything is in order after merge.
