### PR TITLE
chore: ubuntu-20.04 > ubuntu-latest (test-coverage.yml)

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -146,7 +146,7 @@ jobs:
   badge:
     name: Generate badge for coverage
     needs: [coverage]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the badges branch in repo
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
## Issue

Closes #370

## Description
The GitHub workflow for Generage badge for coverage is being cancelled on each run. The problem associated seems to be: https://github.com/actions/runner-images/issues/11101

The solution could be to substitute in the workflow ubuntu-20.04 image label with ubuntu-latest. Hopefully that will work and is an easy fix!

## Definition of Done
- [ ] Job `Generate badge for coverage` won't cancel when merging this branch

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] Package version is incremented



