### PR TITLE
Fix: Page counters in `slope_selector` going past desired range

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9067
+Version: 0.0.0.9068
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/inst/shiny/modules/tab_nca/slope_selector.R
+++ b/inst/shiny/modules/tab_nca/slope_selector.R
@@ -136,6 +136,7 @@ slope_selector_server <- function(
       shinyjs::disable(selector = ".btn-page")
     })
     observeEvent(input$previous_page, {
+      if (current_page() == 1) return(NULL)
       current_page(current_page() - 1)
       shinyjs::disable(selector = ".btn-page")
     })
@@ -202,13 +203,22 @@ slope_selector_server <- function(
         unique() %>%
         arrange(USUBJID)
 
-      num_plots <- nrow(subject_profile_plot_ids)
-
       # find which plots should be displayed based on page #
+      num_plots <- nrow(subject_profile_plot_ids)
       plots_per_page <- as.numeric(input$plots_per_page)
+      num_pages <- ceiling(num_plots / plots_per_page)
+
+      if (current_page() > num_pages) {
+        current_page(current_page() - 1)
+        return(NULL)
+      }
+
       page_end <- current_page() * plots_per_page
       page_start <- page_end - plots_per_page + 1
       if (page_end > num_plots) page_end <- num_plots
+
+      # update page number display #
+      output$page_number <- renderUI(num_pages)
 
       plots_to_render <- slice(ungroup(subject_profile_plot_ids), page_start:page_end)
 
@@ -237,10 +247,6 @@ slope_selector_server <- function(
         shinyjs::enable(selector = ".btn-page")
         plot_outputs
       })
-
-      # update page number display #
-      num_pages <- ceiling(num_plots / plots_per_page)
-      output$page_number <- renderUI(num_pages)
 
       # update jump to page selector #
       updatePickerInput(


### PR DESCRIPTION
## Issue

Closes #212 

## Description

Buttons for selecting page for slope selector plots were not working correctly. Clicking *Previous* on the first page would crash the app, just as pressing *Next* on the last page.

Proposed solution is not ideal and the pagination system could use a rework to make the end user experience better. However, it does solve the issue at hand for now - let me know if this is good enough at the moment.

## Definition of Done

- [x] When reaching the last plot, pressing "Next Page" should not increment the counter beyond the available plots.
- [x] The "Previous Page" button should always navigate correctly without requiring excessive presses.

## How to test

Map the data, go to NCA -> Setup -> Slope selector. Try pressing the *Previous* button on the first page. Navigate to the last page and try pressing the *Next* button.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [ ] Package version is incremented
