### PR TITLE
test: add tests for PKNCA_add_F

### DIFF
--- a/tests/testthat/test-bioavailability.R
+++ b/tests/testthat/test-bioavailability.R
@@ -28,3 +28,26 @@ describe("calculate_F", {
     expect_true(any(is.na(result$f_auclast)) || any(result$f_auclast > 0))
   })
 })
+
+describe("PKNCA_add_F", {
+  it("returns the original object when bioavailability is NULL", {
+    result <- PKNCA_add_F(PKNCA_RESULTS_FIXTURE, NULL)
+    expect_equal(result, PKNCA_RESULTS_FIXTURE)
+  })
+
+  it("adds bioavailability data to the result slot when provided", {
+    bioavailability <- calculate_F(PKNCA_RESULTS_FIXTURE, c("f_auclast", "f_aucinf.obs"))
+
+    result <- PKNCA_add_F(PKNCA_RESULTS_FIXTURE, bioavailability)
+
+    expect_true(all(c("f_auclast","f_aucinf.obs") %in% result$result$PPTESTCD))
+
+    expected_res <- result$result %>%
+      filter(PCSPEC == "Plasma",
+             PPTESTCD %in% c("f_auclast", "f_aucinf.obs"))
+    expect_equal(result$result$PPSTRES[result$result$PPTESTCD == "f_auclast"][1:5],
+                 c(NA, NA, NA, 26.899, 19.98260), tolerance = 1e-4)
+    expect_equal(result$result$PPSTRES[result$result$PPTESTCD == "f_aucinf.obs"][1:5],
+                 as.double(c(NA, NA, NA, NA, NA)), tolerance = 1e-4)
+  })
+})


### PR DESCRIPTION
Contributes to #287 

## Description
### Main implementation
- Added tests for PKNCA_add_F

## Definition of Done
- [x] tests have a 100% coverage for `bioavailability.R` (`covr`)
- [x] tests seem logical

## How to test
- check tests in file `tests/testthat/test-bioavailability.R

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- ~Package version is incremented~