### PR TITLE
Bug: summary stats download not filtered

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9072
+Version: 0.0.0.9073
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/inst/shiny/modules/tab_nca/descriptive_statistics.R
+++ b/inst/shiny/modules/tab_nca/descriptive_statistics.R
@@ -51,7 +51,7 @@ descriptive_statistics_ui <- function(id) {
       reactableOutput(ns("descriptive_stats"))
     ),
     card(
-      downloadButton(ns("download_browser"), "Download the NCA Summary Data")
+      downloadButton(ns("download_summary"), "Download the NCA Summary Data")
     )
   )
 }
@@ -150,9 +150,13 @@ descriptive_statistics_server <- function(id, res_nca, grouping_vars, auc_option
     })
 
     # Download summary statistics as CSV
-    output$download_browser <- downloadHandler(
+    output$download_summary <- downloadHandler(
       filename = function() {
-        paste("NCA_summary.csv")
+        paste0(
+          format(Sys.time(), "%Y-%m-%d"), "_",
+          summary_stats_filtered()$STUDYID[1],
+          "_NCA_summary.csv"
+        )
       },
       content = function(file) {
         log_info("Downloading summary statistics as CSV")

--- a/inst/shiny/modules/tab_nca/descriptive_statistics.R
+++ b/inst/shiny/modules/tab_nca/descriptive_statistics.R
@@ -59,8 +59,6 @@ descriptive_statistics_ui <- function(id) {
 # Server function for the summary statistics module
 descriptive_statistics_server <- function(id, res_nca, grouping_vars, auc_options) {
   moduleServer(id, function(input, output, session) {
-    ns <- session$ns
-
     # Update the input for the group by picker
     observeEvent(res_nca(), {
       req(res_nca())

--- a/inst/shiny/modules/tab_nca/descriptive_statistics.R
+++ b/inst/shiny/modules/tab_nca/descriptive_statistics.R
@@ -107,6 +107,12 @@ descriptive_statistics_server <- function(id, res_nca, grouping_vars, auc_option
       calculate_summary_stats(stats_data, input$summary_groupby)
     })
 
+    summary_stats_filtered <- reactive({
+      summary_stats() %>%
+        select(any_of(c(input$summary_groupby, "Statistic")), input$select_display_parameters) %>%
+        filter(Statistic %in% input$select_display_statistic)
+    })
+
     observeEvent(summary_stats(), {
       req(summary_stats())
 
@@ -129,15 +135,11 @@ descriptive_statistics_server <- function(id, res_nca, grouping_vars, auc_option
 
     # Render the reactive summary table in a data table
     output$descriptive_stats <- renderReactable({
-      req(summary_stats())
-      log_info("Rendering descriptive statistics table")
-
-      data <- summary_stats() %>%
-        select(any_of(c(input$summary_groupby, "Statistic")), input$select_display_parameters) %>%
-        filter(Statistic %in% input$select_display_statistic)
+      req(summary_stats_filtered())
+      log_trace("Rendering descriptive statistics table")
 
       reactable(
-        data,
+        summary_stats_filtered(),
         searchable = TRUE,
         sortable = TRUE,
         highlight = TRUE,
@@ -156,7 +158,7 @@ descriptive_statistics_server <- function(id, res_nca, grouping_vars, auc_option
       },
       content = function(file) {
         log_info("Downloading summary statistics as CSV")
-        write.csv(summary_stats(), file)
+        write.csv(summary_stats_filtered(), file)
       }
     )
 


### PR DESCRIPTION
## Issue

Closes #381 

## Description

Summary stats download will download all the parameters, not just the ones filtered by the user in the table selection. This change filters the summary data table and selects appropriate columns before downloading a file.

## Definition of Done

- [x] Download summary stats only downloads parameters selected by the user.

## How to test

Run the application -> map the data -> run NCA with default parameters. Go into Results -> Descriptive statistics. Go to _Parameter to display_ and _Statistic to display_ widgets, play around with the selections - you can i.e. deselect all and select only the first one. The table should only display relevant columns with parameters and rows with relevant Statistic. This should also be true for the .csv file downloaded using button under the table. 

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] Package version is incremented
