### PR TITLE
Hotfix: typo in tests for `read_pk` function

### DIFF
--- a/tests/testthat/test-read_pk.R
+++ b/tests/testthat/test-read_pk.R
@@ -64,7 +64,8 @@ describe("read_pk", {
 
   it("throws an error if file with unsupported format is loaded", {
     unsupported_path <- withr::local_tempfile(fileext = ".txt")
-    expect_error(read_pk(unsupported_path, "Invalid file type."))
+    writeLines("test", unsupported_path)
+    expect_error(read_pk(unsupported_path), "Invalid file type.")
   })
 
   it("throws an error if loaded object is not a data frame", {


### PR DESCRIPTION
## Issue

Closes #383

## Description

I have noticed a typo in testing suite for `read_pk` function. The regexpr string for `expect_error` function was actually passed to the `read_pk` function instead - which caused an error and passed the check, just not the error we actually want to test for.

This PR fixes the typo and writes to temporary test file, so that `read_pk` throws `Invalid file type=` error, instead of `File does not exist` error.
