### PR TITLE
Enhancement: All flag rule sets automatically selected

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9077
+Version: 0.0.0.9078
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/inst/shiny/modules/tab_nca/nca_setup.R
+++ b/inst/shiny/modules/tab_nca/nca_setup.R
@@ -20,7 +20,7 @@
   fluidRow(
     column(
       width = 6,
-      checkboxInput(rule_id, label)
+      checkboxInput(rule_id, label, value = TRUE)
     ),
     column(
       width = 6,


### PR DESCRIPTION
## Issue

Closes #397 

## Description
In NCA setup, set rule set flags to TRUE by default.

### Definition of Done
- [x] Rule sets are automatically selected

## How to test

Run the application, map the default data. On the NCA -> Setup -> Settings page check if all checkboxes in **Flag Rule Sets** are selected. Run the analysis and check if flags are applied - on dummy data, there should be red-colored result rows.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] Package version is incremented
