### PR TITLE
Enhancement: Preserve exisitng labels in `apply_labels`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9077
+Version: 0.0.0.9079
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/R/label_operators.R
+++ b/R/label_operators.R
@@ -9,33 +9,33 @@
 #'
 #' @return The same dataset with label attributes applied to all columns.
 #' If a column is not present in the labels list, it will be assigned the name of the col.
+#' If label already exists in the original data, it will be preserved.
 #'
 #' @examples
-#' \dontrun{
-#'   # Example usage:
-#'   data <- data.frame(USUBJID = c(1, 2, 3), AVAL = c(4, 5, 6))
-#'   labels <- data.frame(
-#'   Variable = c("USUBJID", "AVAL"),
-#'   Label = c("Unique Subject Identifier", "Analysis Value")
-#'   )
-#'   data <- apply_labels(data, labels)
-#'   print(attr(data$A, "label"))
-#' }
+#'  data <- data.frame(USUBJID = c(1, 2, 3), AVAL = c(4, 5, 6))
+#'  labels <- data.frame(
+#'    Variable = c("USUBJID", "AVAL"),
+#'    Label = c("Unique Subject Identifier", "Analysis Value"),
+#'    Dataset = c("ADPC", "ADPC")
+#'  )
+#'  data <- apply_labels(data, labels, "ADPC")
+#'  print(attr(data$USUBJID, "label")) # "Unique Subject Identifier"
+#'  print(attr(data$AVAL, "label"))    # "Analysis Value"
 #'
+#' @importFrom dplyr filter
+#' @importFrom magrittr `%>%`
 #' @importFrom stats setNames
 #'
 #' @export
 apply_labels <- function(data, labels_df, type) {
-
-  # Create the label_ADNCA named vector from labels_app
-  labels_df %>%
-    filter(Dataset == type)
-
-  label_adnca <- setNames(labels_df$Label, labels_df$Variable)
+  labels_df <- dplyr::filter(labels_df, Dataset == type)
+  labels_reference <- stats::setNames(labels_df$Label, labels_df$Variable)
 
   for (col in colnames(data)) {
-    if (col %in% names(label_adnca)) {
-      attr(data[[col]], "label") <- label_adnca[[col]]
+    if (!is.null(attr(data[[col]], "label"))) next # Preserve existing labels
+
+    if (col %in% names(labels_reference)) {
+      attr(data[[col]], "label") <- labels_reference[[col]]
     } else {
       attr(data[[col]], "label") <- col
     }

--- a/man/apply_labels.Rd
+++ b/man/apply_labels.Rd
@@ -17,20 +17,20 @@ for the dataset you are applying it .}
 \value{
 The same dataset with label attributes applied to all columns.
 If a column is not present in the labels list, it will be assigned the name of the col.
+If label already exists in the original data, it will be preserved.
 }
 \description{
 This function adds "label" attributes to all columns in a dataset
 }
 \examples{
-\dontrun{
-  # Example usage:
-  data <- data.frame(USUBJID = c(1, 2, 3), AVAL = c(4, 5, 6))
-  labels <- data.frame(
-  Variable = c("USUBJID", "AVAL"),
-  Label = c("Unique Subject Identifier", "Analysis Value")
-  )
-  data <- apply_labels(data, labels)
-  print(attr(data$A, "label"))
-}
+ data <- data.frame(USUBJID = c(1, 2, 3), AVAL = c(4, 5, 6))
+ labels <- data.frame(
+   Variable = c("USUBJID", "AVAL"),
+   Label = c("Unique Subject Identifier", "Analysis Value"),
+   Dataset = c("ADPC", "ADPC")
+ )
+ data <- apply_labels(data, labels, "ADPC")
+ print(attr(data$USUBJID, "label")) # "Unique Subject Identifier"
+ print(attr(data$AVAL, "label"))    # "Analysis Value"
 
 }

--- a/tests/testthat/test-label_operators.R
+++ b/tests/testthat/test-label_operators.R
@@ -35,9 +35,9 @@ describe("apply_labels", {
     data_with_existing_labels <- data
     attr(data_with_existing_labels$USUBJID, "label") <- "Existing label for USUBJID"
 
-    labeled_data <- apply_labels(data_with_existing_labels, LABELS, "ADPC")
-    expect_equal(base::attr(data$USUBJID, "label"), "Existing label for USUBJID")
-    expect_equal(base::attr(data$AVAL, "label"), "Analysis Value")
+    labeled_data <- apply_labels(data_with_existing_labels, ADNCA_LABELS_FIXTURE, "ADPC")
+    expect_equal(base::attr(labeled_data$USUBJID, "label"), "Existing label for USUBJID")
+    expect_equal(base::attr(labeled_data$AVAL, "label"), "Analysis Value")
   })
 })
 

--- a/tests/testthat/test-label_operators.R
+++ b/tests/testthat/test-label_operators.R
@@ -14,8 +14,8 @@ describe("apply_labels", {
     data <- apply_labels(data, LABELS, "ADPC")
     expect_equal(attr(data$USUBJID, "label"), "Unique Subject Identifier")
     expect_equal(attr(data$AVAL, "label"), "Analysis Value")
-
   })
+
   it("appplies labels to non matching data", {
     data <- data.frame(
       COL1 = c(1, 2, 3),
@@ -25,6 +25,18 @@ describe("apply_labels", {
     data <- apply_labels(data, LABELS, "ADPC")
     expect_equal(attr(data$COL1, "label"), "COL1")
     expect_equal(attr(data$COL2, "label"), "COL2")
+  })
+
+  it("does not change labels if already applied", {
+    data <- data.frame(
+      USUBJID = c(1, 2, 3),
+      AVAL = c(4, 5, 6)
+    )
+    attr(data$USUBJID, "label") <- "Existing label for USUBJID"
+
+    data <- apply_labels(data, LABELS, "ADPC")
+    expect_equal(attr(data$USUBJID, "label"), "Existing label for USUBJID")
+    expect_equal(attr(data$AVAL, "label"), "Analysis Value")
   })
 })
 

--- a/tests/testthat/test-label_operators.R
+++ b/tests/testthat/test-label_operators.R
@@ -29,8 +29,8 @@ describe("apply_labels", {
     expect_equal(base::attr(labeled_data$AVAL, "label"), "AVAL")
     expect_equal(base::attr(labeled_data$RACE, "label"), "RACE")
   })
-  
-  
+
+
   it("does not change labels if already applied", {
     data_with_existing_labels <- data
     attr(data_with_existing_labels$USUBJID, "label") <- "Existing label for USUBJID"


### PR DESCRIPTION
## Issue
Closes #384 

## Description
If the user uploads an RDS file, any labels already present in the data set should be carried over, and included in all further data processing.

- `apply_labels` function will preserve any existing labels in the incoming data.
- updated docstrings fixing the example usage and adding missing import statements.
- slight refactoring of the `apply_labels` function.

## Definition of Done
- [x] labels retrieved and carried over from rds upload
- [x] labels used for subsequent analysis
- [x] no change if no rds uploaded

## How to test
I think provided unit tests cover expected behavior.

You can additionally create a .rds file with custom labels by loading dummy data, applying labels manually and saving, then running the file through the app and checking if labels are preserved.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] Package version is incremented

## Notes to reviewer
The issue references .rds files specifically (which is really the only file format that will handle label attributes for specific columns). The changes cover this case and __technically__ should not interfere with anything else, but in case we have more such use cases for labels in the future, then the function will always preserve existing ones instead of overwriting.
