### PR TITLE
Enhancement: add tests utils-slope_selector (filter_slopes) - #287 v2

### DIFF
--- a/tests/testthat/test-utils-slope_selector.R
+++ b/tests/testthat/test-utils-slope_selector.R
@@ -197,4 +197,25 @@ describe("check_slope_rule_overlap", {
     expect_equal(nrow(check_slope_rule_overlap(EXISTING_FIXTURE, NEW, slope_groups)), 0)
 
   })
+
+  it("should warn if more than one range for single subject, profile and rule type is detected", {
+    EXISTING <- data.frame(
+      TYPE = "Exclusion",
+      USUBJID = 1,
+      DOSNO = 1,
+      PARAM = "A",
+      PCSPEC = 1,
+      RANGE = "3:6"
+    )
+
+    DUPLICATE <- EXISTING %>%
+      mutate(
+        RANGE = "4:7"
+      )
+
+    expect_warning(
+      check_slope_rule_overlap(rbind(EXISTING, DUPLICATE), DUPLICATE, slope_groups),
+      "More than one range for single subject, profile and rule type detected."
+    )
+  })
 })


### PR DESCRIPTION
Contributes to #287 
Reopened from #364

## Description
* Added test for new warning (duplicated ranges)

## Definition of Done
- [x] tests have a 100% coverage for `utils-slope_selector.R` (`covr`)
- [x] tests are logical

## How to test
- check tests in file `tests/testthat/test-utils-slope_selector.R`
