### PR TITLE
bug: remove AUCINT from default parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9080
+Version: 0.0.0.9081
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/inst/shiny/modules/tab_nca/nca_setup.R
+++ b/inst/shiny/modules/tab_nca/nca_setup.R
@@ -345,7 +345,6 @@ nca_setup_server <- function(id, data, adnca_data) { # nolint : TODO: complexity
 
     DEFAULT_PARAMS <- c(
       "aucinf.obs", "aucinf.obs.dn",
-      "aucint.last",
       "auclast", "auclast.dn",
       "cmax", "cmax.dn",
       "clast.obs", "clast.obs.dn",


### PR DESCRIPTION
## Issue

Closes #404


### Description
Unless selected by the user AUCINT is not computed for each profile... It is rather more expected just to be computed for partial AUCs. 

Definition of Done
AUCINT is not selected by default in the tab NCA setup

## How to test
Start the App > Mapping > NCA setup > Check parameters by default selected

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] Package version is incremented

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
