### PR TITLE
fix: default units table adapted to multiple units per analyte (e.g, PCSPEC) #382

### DIFF
--- a/R/PKNCA.R
+++ b/R/PKNCA.R
@@ -144,21 +144,6 @@ PKNCA_create_data_object <- function(adnca_data) { # nolint: object_name_linter
     intervals = intervals, #TODO: should be default
     units = PKNCA_build_units_table(pknca_conc, pknca_dose)
   )
-browser()
-  # Update units
-  concu_vars <- setdiff(names(getGroups(pknca_conc)), names(getGroups(pknca_dose)))
-  units_table <- pknca_conc$data %>%
-    select(any_of(c(names(getGroups(pknca_conc)), "AVALU", "DOSEU", "RRLTU"))) %>%
-    unique() %>%
-    select_relevant_columns(o_conc$columns$concu)
-  unique_analytes <- unique(
-    pknca_data_object$conc$data[[pknca_data_object$conc$columns$groups$group_analyte]]
-  )
-  analyte_column <- pknca_data_object$conc$columns$groups$group_analyte
-  pknca_data_object$units <- tidyr::crossing(
-    pknca_data_object$units, !!sym(analyte_column) := unique_analytes
-  ) %>%
-    mutate(PPSTRESU = PPORRESU, conversion_factor = 1)
 
   pknca_data_object
 }
@@ -449,8 +434,8 @@ PKNCA_impute_method_start_c1 <- function(conc, time, start, end, ..., options = 
 
 PKNCA_build_units_table <- function(o_conc, o_dose) {
   # Extract relevant columns from o_conc and o_dose
-  group_dose_cols <- names(getGroups(o_dose))
-  group_conc_cols <- names(getGroups(o_conc))
+  group_dose_cols <- names(PKNCA::getGroups(o_dose))
+  group_conc_cols <- names(PKNCA::getGroups(o_conc))
   uconc_col <- o_conc$columns$concu
   utime_col <- o_conc$columns$timeu
   udose_col <- o_dose$columns$doseu

--- a/R/create_start_impute.R
+++ b/R/create_start_impute.R
@@ -21,7 +21,7 @@ create_start_impute <- function(pknca_data) {
   }
 
   # Define column names
-  conc_column <- pknca_data$conc$columns$conc
+  conc_column <- pknca_data$conc$columns$concentration
   time_column <- pknca_data$conc$columns$time
   analyte_column <- pknca_data$conc$columns$groups$group_analyte
   route_column <- pknca_data$dose$columns$route


### PR DESCRIPTION
## Issue

Closes #382

## Description
When multiple analytes are considered in the App with different PCSPEC their units can change. This is something the App was not considering and can confuse in case the scientists want the parameters in those units. So we need to put them by default in those.

## Definition of Done
- [ ] Default unit assignments should also consider PCSPEC (or any other conc group var)
- [ ] Filtering system for the table is not only for analytes

## How to test
- Check a dataset with multiple units for the same analyte (e.g, `Dummy_complex_data.csv`)
- Play with the units table (NCA setup > Select PCSPEC / Analyte > Units table)

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] Package version is incremented

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
