### PR TITLE
fix: set PARAM as default for boxplot colors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9083
+Version: 0.0.0.9085
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/inst/shiny/modules/tab_visuals.R
+++ b/inst/shiny/modules/tab_visuals.R
@@ -436,7 +436,7 @@ tab_visuals_server <- function(id, data, grouping_vars, res_nca) {
         session,
         "selected_colorvars_boxplot",
         choices = colorvar_choices,
-        selected = "DOSNO"
+        selected = "PARAM"
       )
     })
 


### PR DESCRIPTION
## Issue

Closes #424

## Description
Allows boxplot to show by default. This will eliminate some confusion for the users when testing the App ( specially tomorrow! ;] )

## Definition of Done

Boxplots show by default once NCA is run.

## How to test

Map columns > Run NCA > Visualization > Boxplots
A default display should be there

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] Package version is incremented

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
