### PR TITLE
Chore: add cyclomp_linter to `.lintr` file

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters:
   linters_with_defaults(
+    cyclocomp_linter = cyclocomp_linter(complexity_limit = 15),
     line_length_linter = line_length_linter(100),
     object_name_linter = object_name_linter(
         styles = c("snake_case", "SNAKE_CASE")


### PR DESCRIPTION
## Description

Adds `cyclomp_linter` with `complexity_limit` = 15 to `.lintr` file as for some reason, on some systems and package versions the default linters do not include `cyclomp_linter`.

For some reason, `cyclomp_linter` stopped working for me for `aNCA` project and honestly I dunno why - I have checked package and dependency versions, paths and files, but `cyclomp_linter` is not loaded for me ever. Adding it outright to the `.lintr` file has helped - so I am updating the `.lintr` file for the project to avoid such issues in the future.
