### PR TITLE
bug: fix needed R version in description (3.5 > 4.4)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -82,5 +82,5 @@ Config/testthat/edition: 3
 Language: en-US
 URL: https://pharmaverse.github.io/aNCA/, https://github.com/pharmaverse/aNCA
 Depends: 
-    R (>= 3.5)
+    R (>= 4.4)
 LazyData: true


### PR DESCRIPTION
## Issue

Closes #456 

## Description
The description indicated as required for the R version in the descriptions seems to be wrong. A newer one is needed to use tern (4.4)

## Definition of Done
- [ ] Indicate in description the correct needed R version (>=4.4)

## How to test
Check the DESCRIPTION file

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- ~Package version is incremented~

