### PR TITLE
390 enhancement/ux refine data table layouts

### DIFF
--- a/inst/shiny/modules/tab_data.R
+++ b/inst/shiny/modules/tab_data.R
@@ -165,10 +165,13 @@ tab_data_server <- function(id) {
         highlight = TRUE,
         wrap = TRUE,
         resizable = TRUE,
-        defaultPageSize = 25,
+        defaultPageSize = 10,
         showPageSizeOptions = TRUE,
+        pageSizeOptions = c(10, 25, 50, 100, nrow(processed_data())),
         striped = TRUE,
         bordered = TRUE,
+        compact = TRUE,
+        style = list(fontSize = "0.75em"),
         height = "98vh"
       )
     })

--- a/inst/shiny/modules/tab_data/data_mapping.R
+++ b/inst/shiny/modules/tab_data/data_mapping.R
@@ -337,7 +337,11 @@ data_mapping_server <- function(id, adnca_data) {
         onClick = "select",
         compact = TRUE,
         wrap = FALSE,
-        resizable = TRUE
+        resizable = TRUE,
+        showPageSizeOptions = TRUE,
+        pageSizeOptions = c(10, 25, 50, 100, nrow(df_duplicates())),
+        defaultPageSize = 10,
+        style = list(fontSize = "0.75em")
       )
     })
 

--- a/inst/shiny/modules/tab_data/data_upload.R
+++ b/inst/shiny/modules/tab_data/data_upload.R
@@ -94,10 +94,13 @@ data_upload_server <- function(id) {
         highlight = TRUE,
         wrap = FALSE,
         resizable = TRUE,
-        defaultPageSize = 25,
+        defaultPageSize = 10,
         showPageSizeOptions = TRUE,
+        pageSizeOptions = c(10, 25, 50, 100, nrow(raw_data())),
         height = "70vh",
-        class = "reactable-table"
+        class = "reactable-table",
+        compact = TRUE,
+        style = list(fontSize = "0.75em")
       )
     })
 

--- a/inst/shiny/modules/tab_nca.R
+++ b/inst/shiny/modules/tab_nca.R
@@ -202,13 +202,31 @@ tab_nca_server <- function(id, adnca_data, grouping_vars) {
           "Exclude"
         ) %>%
         DT::datatable(
-          extensions = "FixedHeader",
-          options = list(scrollX = TRUE, scrollY = "80vh",
-                         lengthMenu = list(c(10, 25, -1), c("10", "25", "All")),
-                         pageLength = -1, fixedHeader = TRUE)
+          extensions = c("FixedHeader", "Buttons"),
+          options = list(
+            scrollX = TRUE,
+            fixedHeader = TRUE,
+            dom = "Blfrtip",
+            buttons = list(
+              list(extend = "copy", title = paste0("NCA_Slope_Results_", Sys.Date())),
+              list(extend = "csv", filename = paste0("NCA_Slope_Results_", Sys.Date()))
+            ),
+            headerCallback = DT::JS(
+              "function(thead) {",
+              "  $(thead).css('font-size', '0.75em');",
+              "  $(thead).find('th').css('text-align', 'center');",
+              "}"
+            ),
+            columnDefs = list(
+              list(className = "dt-center", targets = "_all")
+            ),
+            lengthMenu = list(c(10, 50, -1), c('10', '50', 'All')),
+            paging = TRUE
+          ),
+          class = "row-border compact",
+          rownames = FALSE
         ) %>%
-        formatStyle("Exclude", target = "row",
-                    backgroundColor = styleEqual(NA, NA, default = "#f5b4b4"))
+        DT::formatStyle(columns = 1:ncol(pivot_wider_pknca_results(res_nca())), fontSize = "75%")
     })
 
     nca_results_server("nca_results", processed_pknca_data, res_nca, settings, grouping_vars)

--- a/inst/shiny/modules/tab_nca.R
+++ b/inst/shiny/modules/tab_nca.R
@@ -220,13 +220,15 @@ tab_nca_server <- function(id, adnca_data, grouping_vars) {
             columnDefs = list(
               list(className = "dt-center", targets = "_all")
             ),
-            lengthMenu = list(c(10, 50, -1), c('10', '50', 'All')),
+            lengthMenu = list(c(10, 50, -1), c("10", "50", "All")),
             paging = TRUE
           ),
           class = "row-border compact",
           rownames = FALSE
         ) %>%
-        DT::formatStyle(columns = 1:ncol(pivot_wider_pknca_results(res_nca())), fontSize = "75%")
+        DT::formatStyle(
+          columns = seq_len(ncol(pivot_wider_pknca_results(res_nca()))), fontSize = "75%"
+        )
     })
 
     nca_results_server("nca_results", processed_pknca_data, res_nca, settings, grouping_vars)

--- a/inst/shiny/modules/tab_nca/descriptive_statistics.R
+++ b/inst/shiny/modules/tab_nca/descriptive_statistics.R
@@ -142,8 +142,12 @@ descriptive_statistics_server <- function(id, res_nca, grouping_vars) {
         wrap = TRUE,
         resizable = TRUE,
         showPageSizeOptions = TRUE,
+        pageSizeOptions = c(10, 25, 50, 100, nrow(summary_stats_filtered())),
+        defaultPageSize = 10,
         striped = TRUE,
-        bordered = TRUE
+        bordered = TRUE,
+        compact = TRUE,
+        style = list(fontSize = "0.75em")
       )
     })
 

--- a/inst/shiny/modules/tab_nca/excretion_analysis.R
+++ b/inst/shiny/modules/tab_nca/excretion_analysis.R
@@ -1,4 +1,3 @@
-
 #' NCA Excretion Analysis Module
 #'
 #' This module handles logic for excretion analysis in NCA.
@@ -190,7 +189,11 @@ excretion_server <- function(id, input_pknca_data) {
       reactable(results_output(),
                 defaultPageSize = 10,
                 searchable = TRUE,
-                highlight = TRUE)
+                highlight = TRUE,
+                compact = TRUE,
+                showPageSizeOptions = TRUE,
+                pageSizeOptions = c(10, 25, 50, 100, nrow(results_output())),
+                style = list(fontSize = "0.75em"))
 
     })
   })

--- a/inst/shiny/modules/tab_nca/nca_results.R
+++ b/inst/shiny/modules/tab_nca/nca_results.R
@@ -171,10 +171,13 @@ nca_results_server <- function(id, pknca_data, res_nca, settings, grouping_vars)
         sortable = TRUE,
         highlight = TRUE,
         resizable = TRUE,
-        defaultPageSize = 25,
+        defaultPageSize = 10,
         showPageSizeOptions = TRUE,
+        pageSizeOptions = c(10, 25, 50, 100, nrow(output_results())),
         striped = TRUE,
         bordered = TRUE,
+        compact = TRUE,
+        style = list(fontSize = "0.75em"),
         height = "68vh",
         rowStyle = function(index) {
           flagged_value <- output_results()$flagged[index]

--- a/inst/shiny/modules/tab_nca/non_nca_ratios.R
+++ b/inst/shiny/modules/tab_nca/non_nca_ratios.R
@@ -130,7 +130,7 @@ non_nca_ratio_server <- function(id, data, grouping_vars) {
         options = list(
           scrollX = TRUE,
           fixedHeader = TRUE,
-          dom = "Bfrtip",
+          dom = "Blfrtip",
           buttons = list(
             list(
               extend = "copy",
@@ -140,9 +140,24 @@ non_nca_ratio_server <- function(id, data, grouping_vars) {
               extend = "csv",
               filename = paste0("Ratios_result_", Sys.Date())
             )
-          )
+          ),
+          headerCallback = DT::JS(
+            "function(thead) {",
+            "  $(thead).css('font-size', '0.75em');",
+            "  $(thead).find('th').css('text-align', 'center');",
+            "}"
+          ),
+          columnDefs = list(
+            list(className = "dt-center", targets = "_all")
+          ),
+          lengthMenu = list(c(10, 50, -1), 
+                            c('10', '50', 'All')),
+          paging = T
         ),
-      )
+        class = "row-border compact",
+        rownames = FALSE
+      ) %>%
+        DT::formatStyle(columns = 1:ncol(full_output()), fontSize = "75%")
     })
 
     # Save the results in the output folder

--- a/inst/shiny/modules/tab_nca/non_nca_ratios.R
+++ b/inst/shiny/modules/tab_nca/non_nca_ratios.R
@@ -150,14 +150,14 @@ non_nca_ratio_server <- function(id, data, grouping_vars) {
           columnDefs = list(
             list(className = "dt-center", targets = "_all")
           ),
-          lengthMenu = list(c(10, 50, -1), 
-                            c('10', '50', 'All')),
-          paging = T
+          lengthMenu = list(c(10, 50, -1),
+                            c("10", "50", "All")),
+          paging = TRUE
         ),
         class = "row-border compact",
         rownames = FALSE
       ) %>%
-        DT::formatStyle(columns = 1:ncol(full_output()), fontSize = "75%")
+        DT::formatStyle(columns = seq_len(ncol(full_output())), fontSize = "75%")
     })
 
     # Save the results in the output folder

--- a/inst/shiny/modules/tab_nca/parameter_datasets.R
+++ b/inst/shiny/modules/tab_nca/parameter_datasets.R
@@ -50,30 +50,25 @@ parameter_datasets_server <- function(id, res_nca) {
     extensions = c("FixedHeader", "Buttons"),
     options = list(
       scrollX = TRUE,
-      scrollY = "80vh",
-      searching = TRUE,
-      fixedColumns = TRUE,
       fixedHeader = TRUE,
-      autoWidth = TRUE,
-      pageLength = -1,
-      lengthMenu = -1,
-      dom = "Bfrtip",
+      dom = "Blfrtip",
       buttons = list(
-        list(
-          extend = "copy",
-          title = paste0(filename, "_", Sys.Date())
-        ),
-        list(
-          extend = "csv",
-          filename = paste0(filename, "_", Sys.Date())
-        ),
-        list(
-          extend = "excel",
-          title = NULL,
-          header = colnames(data),
-          filename = paste0(filename, "_", Sys.Date())
-        )
-      )
-    )
-  )
+        list(extend = "copy", title = paste0(filename, "_", Sys.Date())),
+        list(extend = "csv", filename = paste0(filename, "_", Sys.Date()))
+      ),
+      headerCallback = DT::JS(
+        "function(thead) {",
+        "  $(thead).css('font-size', '0.75em');",
+        "  $(thead).find('th').css('text-align', 'center');",
+        "}"
+      ),
+      columnDefs = list(
+        list(className = "dt-center", targets = "_all")
+      ),
+      lengthMenu = list(c(10, 50, -1), c('10', '50', 'All')),
+      paging = TRUE
+    ),
+    class = "row-border compact"
+  ) %>%
+    DT::formatStyle(columns = seq_len(ncol(data)), fontSize = "75%")
 }

--- a/inst/shiny/modules/tab_nca/parameter_datasets.R
+++ b/inst/shiny/modules/tab_nca/parameter_datasets.R
@@ -65,7 +65,7 @@ parameter_datasets_server <- function(id, res_nca) {
       columnDefs = list(
         list(className = "dt-center", targets = "_all")
       ),
-      lengthMenu = list(c(10, 50, -1), c('10', '50', 'All')),
+      lengthMenu = list(c(10, 50, -1), c("10", "50", "All")),
       paging = TRUE
     ),
     class = "row-border compact"

--- a/inst/shiny/modules/tab_tlg.R
+++ b/inst/shiny/modules/tab_tlg.R
@@ -156,7 +156,7 @@ tab_tlg_server <- function(id, data) {
             )
           ),
           rowGroup = list(dataSrc = which(names(tlg_order()) %in% c("Type", "Dataset"))),
-          lengthMenu = list(c(10, 50, -1), c('10', '50', 'All')),
+          lengthMenu = list(c(10, 50, -1), c("10", "50", "All")),
           paging = TRUE
         ),
         class = "row-border compact"
@@ -226,7 +226,7 @@ tab_tlg_server <- function(id, data) {
             list(width = "150px", targets = "_all")
           ),
           rowGroup = list(dataSrc = which(names(tlg_order()) %in% c("Type", "Dataset"))),
-          lengthMenu = list(c(10, 50, -1), c('10', '50', 'All')),
+          lengthMenu = list(c(10, 50, -1), c("10", "50", "All")),
           paging = TRUE
         ),
         class = "row-border compact"

--- a/inst/shiny/modules/tab_tlg.R
+++ b/inst/shiny/modules/tab_tlg.R
@@ -115,7 +115,6 @@ tab_tlg_server <- function(id, data) {
     output$selected_tlg_table <- DT::renderDT({
       log_trace("Rendering TLG table.")
       datatable(
-        class = "table table-striped table-bordered",
         data = dplyr::filter(tlg_order(), Selection),
         editable = list(
           target = "cell",
@@ -128,15 +127,24 @@ tab_tlg_server <- function(id, data) {
         selection = list(
           mode = "multiple"
         ),
-        extensions = c("RowGroup"),
+        extensions = c("RowGroup", "Buttons"),
         options = list(
-          paging = FALSE,
-          searching = TRUE,
-          autoWidth = TRUE,
-          dom = "ft",
+          scrollX = TRUE,
+          fixedHeader = TRUE,
+          dom = "Blfrtip",
+          buttons = list(
+            list(extend = "copy", title = paste0("TLG_table_", Sys.Date())),
+            list(extend = "csv", filename = paste0("TLG_table_", Sys.Date()))
+          ),
+          headerCallback = DT::JS(
+            "function(thead) {",
+            "  $(thead).css('font-size', '0.75em');",
+            "  $(thead).find('th').css('text-align', 'center');",
+            "}"
+          ),
           columnDefs = list(
-            list(width = "150px", targets = "_all"),
             list(className = "dt-center", targets = "_all"),
+            list(width = "150px", targets = "_all"),
             list(
               visible = FALSE,
               targets = c(
@@ -147,12 +155,15 @@ tab_tlg_server <- function(id, data) {
               )
             )
           ),
-          rowGroup = list(dataSrc = which(names(tlg_order()) %in% c("Type", "Dataset")))
-        )
+          rowGroup = list(dataSrc = which(names(tlg_order()) %in% c("Type", "Dataset"))),
+          lengthMenu = list(c(10, 50, -1), c('10', '50', 'All')),
+          paging = TRUE
+        ),
+        class = "row-border compact"
       ) %>%
         formatStyle(
           columns = colnames(tlg_order()),
-          fontSize = "14px",
+          fontSize = "75%",
           fontFamily = "Arial"
         )
     }, server = FALSE)
@@ -195,28 +206,36 @@ tab_tlg_server <- function(id, data) {
         selection = list(mode = "multiple"),
         escape = FALSE,
         editable = FALSE,
-        class = "table table-striped table-bordered",
-        extensions = c("RowGroup", "Select"),
+        extensions = c("RowGroup", "Select", "Buttons"),
         options = list(
-          paging = FALSE,
-          searching = TRUE,
-          autoWidth = TRUE,
-          dom = "ft",
+          scrollX = TRUE,
+          fixedHeader = TRUE,
+          dom = "Blfrtip",
+          buttons = list(
+            list(extend = "copy", title = paste0("TLG_modal_table_", Sys.Date())),
+            list(extend = "csv", filename = paste0("TLG_modal_table_", Sys.Date()))
+          ),
+          headerCallback = DT::JS(
+            "function(thead) {",
+            "  $(thead).css('font-size', '0.75em');",
+            "  $(thead).find('th').css('text-align', 'center');",
+            "}"
+          ),
           columnDefs = list(
-            list(
-              visible = FALSE,
-              targets = which(!names(tlg_order()) %in% c("Type", "Dataset", "PKid", "Label"))
-            ),
-            list(targets = 0, orderable = FALSE, className = "select-checkbox")
+            list(className = "dt-center", targets = "_all"),
+            list(width = "150px", targets = "_all")
           ),
-          select = list(
-            style = "multiple",
-            selector = "td:first-child",
-            server = FALSE
-          ),
-          rowGroup = list(dataSrc = which(names(tlg_order()) %in% c("Type", "Dataset")))
+          rowGroup = list(dataSrc = which(names(tlg_order()) %in% c("Type", "Dataset"))),
+          lengthMenu = list(c(10, 50, -1), c('10', '50', 'All')),
+          paging = TRUE
+        ),
+        class = "row-border compact"
+      ) %>%
+        formatStyle(
+          columns = colnames(tlg_order()),
+          fontSize = "75%",
+          fontFamily = "Arial"
         )
-      )
     })
 
     # Update the Selection column when the confirm_add_tlg button is pressed

--- a/inst/shiny/modules/tab_tlg/tlg_option_table.R
+++ b/inst/shiny/modules/tab_tlg/tlg_option_table.R
@@ -84,6 +84,11 @@ tlg_option_table_server <- function(id, opt_def, data, reset_trigger) {
         highlight = TRUE,
         columns = edit_widgets,
         selection = "multiple",
+        compact = TRUE,
+        style = list(fontSize = "0.75em"),
+        showPageSizeOptions = TRUE,
+        pageSizeOptions = c(10, 25, 50, 100, nrow(edits_table())),
+        defaultPageSize = 10,
         theme = reactableTheme(
           rowSelectedStyle = list(backgroundColor = "#eee", boxShadow = "inset 2px 0 0 0 #ffa62d")
         )


### PR DESCRIPTION
## Issue

Closes #

## Description
Data tables not always easy to view, especially when using small screen. Want to ensure the following:

Data table does not take up more than the full page
Scrolling horizontally and vertically can be done in one page
Text is a bit smaller so its easier to see
No wrap on text in rows- and rows fully expanded if possible
Possibility to select 'all" for page pagination options, so all data can be seen on the same page

## Definition of Done
The requirements for the feature to be complete:
- [ ] All data tables formatted the same
- [ ] Text small and easy to read, with limited scrolling
- [ ] Information all present

## How to test
Check all tables through the App (datatables and/or reactables) to seee that they have
- pagination for all rows possibility
- smaller text 
- more compact columns to see more columns than before

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] Package version is incremented

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
