### PR TITLE
Enhancement: refresh when restart button clicked

### DIFF
--- a/inst/shiny/modules/tab_data.R
+++ b/inst/shiny/modules/tab_data.R
@@ -90,8 +90,7 @@ tab_data_server <- function(id) {
     })
 
     observeEvent(input$restart, {
-      data_step(steps[1])
-      updateTabsetPanel(session, "data_navset", selected = step_labels[1])
+      shinyjs::refresh()
     })
 
     observeEvent(input$next_step, {


### PR DESCRIPTION
## Issue

Closes #569 

## Description

When restart button is clicked in the data tab workflow, rather than just taking you back to page 1 it refreshes the app for a real restart. This will prevent crashes caused by uploading new data after mapping previously.

## Definition of Done

- [ ] Restart button refreshes the app

## How to test
 
Run through various steps of data tab workflow and click restart.

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] Package version is incremented

