### PR TITLE
Bug: individual plots duplicate points when colour by profile

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9124
+Version: 0.0.0.9126
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/R/general_lineplot.R
+++ b/R/general_lineplot.R
@@ -204,12 +204,6 @@ preprocess_data_for_plot <- function(
       PCSPEC %in% selected_pcspec,
       if ("EVID" %in% names(data)) EVID == 0 else TRUE,
       !is.na(AVAL)
-    ) %>%
-    mutate(
-      USUBJID = factor(USUBJID),
-      NCA_PROFILE = factor(NCA_PROFILE),
-      DOSEA = factor(DOSEA),
-      color_var = interaction(!!!syms(colorby_var), sep = ", ")
     )
 
   # Handle log scale filtering
@@ -229,5 +223,11 @@ preprocess_data_for_plot <- function(
     processed <- processed %>% filter(NCA_PROFILE %in% cycle)
   }
 
-  processed
+  processed %>%
+    mutate(
+      USUBJID = factor(USUBJID),
+      NCA_PROFILE = factor(NCA_PROFILE),
+      DOSEA = factor(DOSEA),
+      color_var = interaction(!!!syms(colorby_var), sep = ", ")
+    )
 }


### PR DESCRIPTION
## Issue

Closes #171 

## Description

Individual plots when plotting by dose profile had the duplicated points (created with `dose_profile_duplicates()` labelled as the wrong dose profile because the color_var id was created before the duplicates. I moved it so that this is created afterwards and therefore matches the new duplicated points.

## Definition of Done

- [x] Bug fixed
- [x] Dose profile plots have correct colours

## How to test

Individual plots -> colour by NCA_PROFILE -> plot by dose profile and select profile == 1 -> view only 1 NCA_PROFILE colour on graph and in legend.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [ ] Package version is incremented
