### PR TITLE
Remove conversion warning in unit tests

### DIFF
--- a/tests/testthat/test-conversions.R
+++ b/tests/testthat/test-conversions.R
@@ -216,7 +216,7 @@ describe("convert_volume_units()", {
       stringsAsFactors = FALSE
     )
 
-    result <- convert_volume_units(df)
+    result <- suppressWarnings(convert_volume_units(df))
     expect_true(is.na(result$AMOUNTU))
 
   })


### PR DESCRIPTION
## Issue

Description
When the unit tests are done, a warning from testing convert_volume_units always appears.

Expected behaviour
Find out why the warning appears and remove it

Closes #600 

## Description

A warning always appears in the conversions unit tests because of the last test, checking that an unknown unit is rightfully set to NA. The warning appears because a warning function is called in the error section of the tryCatch() function in convert_volume_units.
We want to keep this warning in case the user sets an incorrect unit but remove it for the tests, so I just added a suppressWarnings in the test.

## Definition of Done

- [ ] No warnings when tests are run

## How to test

Run unit tests

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] Package version is incremented
