### PR TITLE
fix: update PKNCA version to 0.12.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     ggplot2,
     magrittr,
     methods,
-    PKNCA (>= 0.12.0),
+    PKNCA (>= 0.12.1),
     plotly,
     purrr,
     rlang,


### PR DESCRIPTION
## Issue

Closes #625 

## Description
Users were experiencing problems due to the last transition in the App on the new PKNCA update (#614). I forgot to update the description accordingly.

## Definition of Done
- NCA can be run in `aNCA` without issues when the package is downloaded

## How to test
Check NCA button runs well in the app on the specified version of PKNCA (0.12.1)

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- ~Package version is incremented~

