### PR TITLE
Enhancement: Excretion analysis in output folder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9154
+Version: 0.0.0.9155
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9155
+Version: 0.0.0.9154
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.0.0.9153
+Version: 0.0.0.9154
 Authors@R: c(
     person("Ercan", "Suekuer", , "ercan.suekuer@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/aNCA.Rproj
+++ b/aNCA.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: e22d3889-c2ee-4710-bc78-ebb6f405e258
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/inst/shiny/modules/tab_nca/excretion_analysis.R
+++ b/inst/shiny/modules/tab_nca/excretion_analysis.R
@@ -199,7 +199,7 @@ excretion_server <- function(id, input_pknca_data) {
       pageSizeOptions = reactive(c(10, 25, 50, 100, nrow(results_output()))),
       style = list(fontSize = "0.75em")
     )
-    
+
     # Save the results in the output folder
     observeEvent(results_output(), {
       session$userData$results$additional_analysis$excretion_results <- results_output()

--- a/inst/shiny/modules/tab_nca/excretion_analysis.R
+++ b/inst/shiny/modules/tab_nca/excretion_analysis.R
@@ -199,5 +199,10 @@ excretion_server <- function(id, input_pknca_data) {
       pageSizeOptions = reactive(c(10, 25, 50, 100, nrow(results_output()))),
       style = list(fontSize = "0.75em")
     )
+    
+    # Save the results in the output folder
+    observeEvent(results_output(), {
+      session$userData$results$additional_analysis$excretion_results <- results_output()
+    })
   })
 }


### PR DESCRIPTION
/data## Issue

Closes #660 

## Description
Excretion analysis table in output folder

## Definition of Done

- [x] Excretion analysis in output folder

## How to test
use `dummy_adnca_sm_dataset  `in `testthat/data` folder to create excretion parameters. Export output zip.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] Package version is incremented

