### PR TITLE
Bug: nca loading won't close if error

### DIFF
--- a/inst/shiny/functions/loading_popup.R
+++ b/inst/shiny/functions/loading_popup.R
@@ -12,7 +12,7 @@ loading_popup <- function(text = "Loading...") {
   showModal(modalDialog(
     modal_body,
     title = span(text, id = "loading-title"),
-    footer = modalButton("Close"),
+    footer = NULL,
     size = "s"
   ))
 }

--- a/inst/shiny/functions/loading_popup.R
+++ b/inst/shiny/functions/loading_popup.R
@@ -12,7 +12,7 @@ loading_popup <- function(text = "Loading...") {
   showModal(modalDialog(
     modal_body,
     title = span(text, id = "loading-title"),
-    footer = NULL,
-    size = "m"
+    footer = modalButton("Close"),
+    size = "s"
   ))
 }

--- a/inst/shiny/modules/tab_nca.R
+++ b/inst/shiny/modules/tab_nca.R
@@ -217,6 +217,7 @@ tab_nca_server <- function(id, adnca_data, grouping_vars) {
       }, error = function(e) {
         log_error("Error calculating NCA results:\n{conditionMessage(e)}")
         showNotification(.parse_pknca_error(e), type = "error", duration = NULL)
+        removeModal()
         NULL
       })
     }) |>


### PR DESCRIPTION
## Issue

Closes #655 

## Description

When an error caused the NCA run to fail, the modal loading pop up would not close so the user is stuck. I considered two possibilities: adding a close button so the user can close the modal, or closing it automatically upon error. I decided to go for the latter since having a manual close button could be misleading and make the user think that they can cancel the run (they cant)

## Definition of Done

- [ ] Loading bar NCA modal closes if error
- [ ] Loading bar NCA remains open until results are shown if no error.

## How to test

Run NCA for a couple of processes:

- Normal workflow (check everything is normal)
- Select all standard parameters (this will give an error because not all parameters can be calculated for the dummy data)
- Go to Slope Selector and add an exclusion with no reason -> Run NCA (should give error because no reason is given)
- Try any other runs that you think may be useful.

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] Package version is incremented
