### PR TITLE
Enhancement: disable next button during processing in data tab

### DIFF
--- a/inst/shiny/modules/tab_data.R
+++ b/inst/shiny/modules/tab_data.R
@@ -92,6 +92,7 @@ tab_data_server <- function(id) {
       session$reload()
     })
     observeEvent(input$next_step, {
+      shinyjs::disable("next_step") # Disable button on click
       current_step <- isolate(data_step())
       if (current_step %in% c("upload", "filtering")) {
         idx <- match(current_step, steps)
@@ -100,10 +101,16 @@ tab_data_server <- function(id) {
       } else if (current_step == "mapping") {
         trigger_mapping_submit(trigger_mapping_submit() + 1)
       } else if (current_step == "preview") {
-        shinyjs::runjs("document.querySelector(`a[data-value='exploration']`).click();"
-        )
+        shinyjs::runjs("document.querySelector(`a[data-value='exploration']`).click();")
       }
     })
+
+    # enable next step after progression
+    observe({
+      data_step()
+      shinyjs::enable("next_step")
+    })
+
     observeEvent(input$prev_step, {
       current <- data_step()
       idx <- match(current, steps)


### PR DESCRIPTION
## Issue

Closes #682 

## Description

Preclinical data causes slow loading, which led to users clicking next button when processing was still going on behind the scenes. To prevent this, the next button is now disabled until the next stepper is shown.

## Definition of Done

- [ ] Next button disabled during loading

## How to test

Test with normal workflow, or using `dummy_adnca_sm.csv` data in `testthat` folder. Go through data tab and see button disable.

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] Package version is incremented

## Notes to reviewer

I've investigated, and this is due to the conversion of volume units in `PKNCA_create_data_object`function. Purely due to the fact that in the preclinical data there are usually more PCSPEC and so there are then more units to convert, so the function takes longer. However this is then improved by  #605  and #665  so I think the time will be significantly reduced anyway, the button disable is useful just incase someone has a larger dataset.
