### PR TITLE
Bug:  bioavailability calculations not working

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -80,7 +80,6 @@
     "REASON",
     "Ratio",
     "Ratio_Type",
-    "route_names",
     "SD",
     "SD_max",
     "SD_min",


### PR DESCRIPTION
## Issue

Closes #705 

## Description

Bioavailability calculations were not working due to an uncaught bug after updating PKNCADose object to remove PCSPEC. Therefore grouping of dose info was not correct and the bioavailability calculations were failing. Fixed now by updating grouping.

## Definition of Done

- [ ] Bioavailability calculated for subjects correctly

## How to test

Use dummy_adnca_sm.csv in testthat folder, and select bioavailability parameters. Check that the results look correct and are in the correct rows.

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] Package version is incremented

