### PR TITLE
743_bug:  Badge for code coverage missing actual %

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,9 +41,11 @@ RoxygenNote: 7.3.3
 Suggests:
     arrow,
     covr,
+    DT,
     ggh4x,
     glue,
     haven,
+    htmltools,
     htmlwidgets,
     jsonlite,
     knitr,


### PR DESCRIPTION


## Issue
Github action fails to create coverage badge correctly:  missing %
Closes #743

## Description

Change description.
Add package `covr` to DESCRIPTION, suggests.   
Github actions will pick up covr as a dependency.

## Definition of Done

Badge created with correct percent coverage.

## How to test
github actions 

How to test features not covered by unit tests.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- ~~Package version is incremented~~

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
