### PR TITLE
Tests: skip `read_pk` tests if packages are missing

### DIFF
--- a/tests/testthat/test-read_pk.R
+++ b/tests/testthat/test-read_pk.R
@@ -19,6 +19,8 @@ describe("read_pk", {
   })
 
   it("reads excel data correctly", {
+    if (!requireNamespace("openxlsx2", quietly = TRUE)) skip("openxlsx2 package not installed")
+
     tmp_xlsx <- withr::local_tempfile(fileext = ".xlsx")
     openxlsx2::write_xlsx(data_dummy, tmp_xlsx)
 
@@ -29,6 +31,8 @@ describe("read_pk", {
   })
 
   it("reads sas data correctly", {
+    if (!requireNamespace("haven", quietly = TRUE)) skip("haven package not installed")
+
     tmp_sas <- withr::local_tempfile(fileext = ".sas7bdat")
     suppressWarnings(haven::write_sas(data_dummy, tmp_sas))
 
@@ -39,6 +43,8 @@ describe("read_pk", {
   })
 
   it("reads xpt files correctly", {
+    if (!requireNamespace("haven", quietly = TRUE)) skip("haven package not installed")
+
     tmp_xpt <- withr::local_tempfile(fileext = ".xpt")
     haven::write_xpt(data_dummy, tmp_xpt)
 
@@ -49,6 +55,8 @@ describe("read_pk", {
   })
 
   it("reads parquet files correctly", {
+    if (!requireNamespace("arrow", quietly = TRUE)) skip("arrow package not installed")
+
     tmp_parquet <- withr::local_tempfile(fileext = ".parquet")
     arrow::write_parquet(data_dummy, tmp_parquet)
 


### PR DESCRIPTION
## Description

Automatic tests on CRAN returned an error:

```R
   ══ Failed tests ════════════════════════════════════════════════════════════════
    ── Error ('test-read_pk.R:25:5'): read_pk: reads excel data correctly ──────────
    Error in `readers[[format]](path)`: Handling .xlsx files requires `openxlsx2` package, please install it with `install.packages('openxlsx2')`
    Backtrace:
        ▆
     1. └─aNCA::read_pk(tmp_xlsx) at test-read_pk.R:25:5
     2.   ├─aNCA:::validate_pk(readers[[format]](path))
     3.   └─readers[[format]](path)
    ── Error ('test-read_pk.R:35:5'): read_pk: reads sas data correctly ────────────
    Error in `readers[[format]](path)`: Handling .sas7bdat files requires `haven` package, please install it with `install.packages('haven')`
    Backtrace:
        ▆
     1. └─aNCA::read_pk(tmp_sas) at test-read_pk.R:35:5
     2.   ├─aNCA:::validate_pk(readers[[format]](path))
     3.   └─readers[[format]](path)
    ── Error ('test-read_pk.R:45:5'): read_pk: reads xpt files correctly ───────────
    Error in `readers[[format]](path)`: Handling .xpt files requires `haven` package, please install it with `install.packages('haven')`
    Backtrace:
        ▆
     1. └─aNCA::read_pk(tmp_xpt) at test-read_pk.R:45:5
     2.   ├─aNCA:::validate_pk(readers[[format]](path))
     3.   └─readers[[format]](path)
    ── Error ('test-read_pk.R:55:5'): read_pk: reads parquet files correctly ───────
    Error in `readers[[format]](path)`: Handling .parquet files requires `arrow` package, please install it with `install.packages('arrow')`
    Backtrace:
        ▆
     1. └─aNCA::read_pk(tmp_parquet) at test-read_pk.R:55:5
     2.   ├─aNCA:::validate_pk(readers[[format]](path))
     3.   └─readers[[format]](path)

    [ FAIL 4 | WARN 0 | SKIP 13 | PASS 733 ]
```

I guess the workflows on CRAN servers do not load suggested packages.

## Definition of Done

Tests do not fail if suggested packages are not installed.

## How to test

Uninstall any of the suggested packages (`haven`, `arrow`, `openxlsx2`) and try running the tests. They should be skipped and reason should be displayed.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
