### PR TITLE
read_pk tests: skip_if_not_installed() & if not skip_on_cran()

### DIFF
--- a/tests/testthat/test-read_pk.R
+++ b/tests/testthat/test-read_pk.R
@@ -19,7 +19,8 @@ describe("read_pk", {
   })
 
   it("reads excel data correctly", {
-    if (!requireNamespace("openxlsx2", quietly = TRUE)) skip("openxlsx2 package not installed")
+    skip_if_not_installed("openxlsx2")
+    skip_on_cran()
 
     tmp_xlsx <- withr::local_tempfile(fileext = ".xlsx")
     openxlsx2::write_xlsx(data_dummy, tmp_xlsx)
@@ -31,7 +32,8 @@ describe("read_pk", {
   })
 
   it("reads sas data correctly", {
-    if (!requireNamespace("haven", quietly = TRUE)) skip("haven package not installed")
+    skip_if_not_installed("haven")
+    skip_on_cran()
 
     tmp_sas <- withr::local_tempfile(fileext = ".sas7bdat")
     suppressWarnings(haven::write_sas(data_dummy, tmp_sas))
@@ -43,7 +45,8 @@ describe("read_pk", {
   })
 
   it("reads xpt files correctly", {
-    if (!requireNamespace("haven", quietly = TRUE)) skip("haven package not installed")
+    skip_if_not_installed("haven")
+    skip_on_cran()
 
     tmp_xpt <- withr::local_tempfile(fileext = ".xpt")
     haven::write_xpt(data_dummy, tmp_xpt)
@@ -55,7 +58,8 @@ describe("read_pk", {
   })
 
   it("reads parquet files correctly", {
-    if (!requireNamespace("arrow", quietly = TRUE)) skip("arrow package not installed")
+    skip_if_not_installed("arrow")
+    skip_on_cran()
 
     tmp_parquet <- withr::local_tempfile(fileext = ".parquet")
     arrow::write_parquet(data_dummy, tmp_parquet)


### PR DESCRIPTION
## Issue

Closes #770

## Description

I will try again, this time with another option to skip the tests and if not, using the skip_on_cran(). That way we will see if the first ones are already enough 


CRAN keeps providing this issue despite our previous tries to fix this (#764):

```
══ Failed tests ════════════════════════════════════════════════════════════════
    ── Error ('test-read_pk.R:27:5'): read_pk: reads excel data correctly ──────────
    Error in `readers[[format]](path)`: Handling .xlsx files requires `openxlsx2` package, please install it with `install.packages('openxlsx2')`
    Backtrace:
        ▆
     1. └─aNCA::read_pk(tmp_xlsx) at test-read_pk.R:27:5
     2.   ├─aNCA:::validate_pk(readers[[format]](path))
     3.   └─readers[[format]](path)
    ── Error ('test-read_pk.R:39:5'): read_pk: reads sas data correctly ────────────
    Error in `readers[[format]](path)`: Handling .sas7bdat files requires `haven` package, please install it with `install.packages('haven')`
    Backtrace:
        ▆
     1. └─aNCA::read_pk(tmp_sas) at test-read_pk.R:39:5
     2.   ├─aNCA:::validate_pk(readers[[format]](path))
     3.   └─readers[[format]](path)
    ── Error ('test-read_pk.R:51:5'): read_pk: reads xpt files correctly ───────────
    Error in `readers[[format]](path)`: Handling .xpt files requires `haven` package, please install it with `install.packages('haven')`
    Backtrace:
        ▆
     1. └─aNCA::read_pk(tmp_xpt) at test-read_pk.R:51:5
     2.   ├─aNCA:::validate_pk(readers[[format]](path))
     3.   └─readers[[format]](path)
    ── Error ('test-read_pk.R:63:5'): read_pk: reads parquet files correctly ───────
    Error in `readers[[format]](path)`: Handling .parquet files requires `arrow` package, please install it with `install.packages('arrow')`
    Backtrace:
        ▆
     1. └─aNCA::read_pk(tmp_parquet) at test-read_pk.R:63:5
     2.   ├─aNCA:::validate_pk(readers[[format]](path))
     3.   └─readers[[format]](path)
```

## How to test
- Tests do not fail if openxlsx2, haven and/or arrow are not installed
- Tests are skipped in automatic CRAN checks


## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- ~~Package version is incremented~~

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
