### PR TITLE
Include CRAN installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,17 @@ This application enables users to upload their datasets and perform Non-Compartm
 
 ## Installation
 
-### Via pak (recommended)
+### From CRAN 
+
+The stable version of the package can be easily downloaded:
+
+```R
+install.packages("aNCA")
+```
+
+---
+
+### From GitHub
 
 We recommend using [pak](https://github.com/r-lib/pak) for package installation, along with all system dependencies. If you do not have `pak` available, you will need to set it up first:
 
@@ -44,6 +54,8 @@ pak::pak("pharmaverse/aNCA")
 ```
 
 in your R console.
+
+---
 
 ### Via cloning the repository (for contributors)
 


### PR DESCRIPTION
Updated installation instructions for the package to include options from CRAN

## Issue

Closes #110

## Description
This pull request updates the installation instructions in the `README.md` to clarify how users can install the package from CRAN and GitHub. The main changes reorganize the installation section for better readability and user guidance.

Installation instructions improvements:

* Added a new subsection for installing the stable version from CRAN, including an example `install.packages("aNCA")` command.


## Definition of Done
- [ ] Include download through CRAN


## Contributor checklist
Documentation: (None)

