### PR TITLE
fix: HL parameters being NA for no reason & flags with no rules (#896)

### DIFF
--- a/R/intervals.R
+++ b/R/intervals.R
@@ -209,13 +209,13 @@ apply_imputation <- function(data, nca_parameters = metadata_nca_parameters) {
   data <- create_start_impute(data)
 
   # Don't impute parameters that are not AUC dependent
-  params_auc_dep <- nca_parameters %>%
-    filter(grepl("auc|aumc", PKNCA) | grepl("auc", Depends)) %>%
+  params_hl_dep <- nca_parameters %>%
+    filter(grepl("auc|aumc|lambda.z|half.life", PKNCA) | grepl("auc|half.life|lambda.z", Depends)) %>%
     pull(PKNCA)
 
   params_not_to_impute <- nca_parameters %>%
     filter(!grepl("auc|aumc", PKNCA),
-           !grepl(paste0(params_auc_dep, collapse = "|"), Depends)) %>%
+           !grepl(paste0(params_hl_dep, collapse = "|"), Depends)) %>%
     pull(PKNCA) %>%
     intersect(names(PKNCA::get.interval.cols()))
 


### PR DESCRIPTION
## Issue

Closes

## Description
This pull request updates the logic for determining which pharmacokinetic parameters should be imputed in the `apply_imputation` function. The main change is to expand the set of parameters considered dependent on half-life or lambda.z, ensuring that imputation is skipped for parameters that depend on these as well as AUC/AUMC.

**Imputation logic improvements:**

* Expanded the set of parameters (`params_hl_dep`) to include those related to `lambda.z` and `half.life` in addition to `auc` and `aumc`, both in the parameter name and dependencies, to more accurately identify parameters that should not be imputed.
* Updated the filtering logic for `params_not_to_impute` to use the new `params_hl_dep` set, ensuring that any parameter depending on AUC, AUMC, lambda.z, or half-life is excluded from imputation.

## Definition of Done
- [ ] If rules are not selected, they should not be applied to the NCA calculation.

## How to test
In dummy data, add manual selection to Subj 1, Range 6:7. Run NCA and view that row is "MISSING" this is expected. Then deselect all rule sets and rerun, row is still "MISSING".

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] App or package changes are reflected in NEWS
- [ ] Package version is incremented

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
