### PR TITLE
closes #755 removing hardcoded DOSEA

### DIFF
--- a/R/PKNCA.R
+++ b/R/PKNCA.R
@@ -63,7 +63,7 @@
 #' @importFrom stats as.formula
 #'
 #' @export
-PKNCA_create_data_object <- function(adnca_data, nca_exclude_reason_columns = NULL) { # nolint: object_name_linter
+PKNCA_create_data_object <- function(adnca_data, nca_exclude_reason_columns = NULL,dose_column = "DOSEA") { # nolint: object_name_linter
   # Define column names based on ADNCA vars
   group_columns <- intersect(colnames(adnca_data), c("STUDYID", "ROUTE", "DOSETRT"))
   usubjid_column <- "USUBJID"
@@ -87,7 +87,7 @@ PKNCA_create_data_object <- function(adnca_data, nca_exclude_reason_columns = NU
     as.formula()
 
   dose_formula <-
-    "DOSEA ~ {time_column} | {studyid_column} + {drug_column} + {usubjid_column}" %>% # nolint
+    "{dose_column} ~ {time_column} | {studyid_column} + {drug_column} + {usubjid_column}" %>% # nolint
     glue::glue() %>%
     as.formula()
 
@@ -149,7 +149,11 @@ PKNCA_create_data_object <- function(adnca_data, nca_exclude_reason_columns = NU
     pkncaconc_data = df_conc,
     group_columns = c(group_columns, usubjid_column)
   )
-
+  
+  if (!dose_column %in% names(df_dose) && "DOSEA" %in% names(df_dose)) {
+    df_dose <- dplyr::rename(df_dose, !!dose_column := DOSEA)
+  }
+  
   pknca_dose <- PKNCA::PKNCAdose(
     data = df_dose,
     formula = dose_formula,

--- a/man/PKNCA_create_data_object.Rd
+++ b/man/PKNCA_create_data_object.Rd
@@ -4,7 +4,11 @@
 \alias{PKNCA_create_data_object}
 \title{Creates a \code{PKNCA::PKNCAdata} object.}
 \usage{
-PKNCA_create_data_object(adnca_data, nca_exclude_reason_columns = NULL)
+PKNCA_create_data_object(
+  adnca_data,
+  nca_exclude_reason_columns = NULL,
+  dose_column = "DOSEA"
+)
 }
 \arguments{
 \item{adnca_data}{Data table containing ADNCA data.}


### PR DESCRIPTION
## Issue

Closes #755   

## Description
This PR removes hardcoded use of DOSEA in the PKNCA object creation workflow. The dose amount variable is now taken from the app’s column-mapping configuration (data$dose$columns$dose) and used consistently when building the PKNCAdose/PKNCAdata objects and any downstream joins/plots that rely on the dose column.

This keeps existing behavior for standard ADNCA inputs while enabling datasets where the dose amount column is not named DOSEA (e.g., DOSEAMT, EXDOSE), as long as the user maps the correct dose column in the app.

Change description.

## Definition of Done

- [ ]  Remove hardcoding of DOSEA (dose amount) in the app workflow and underlying helpers.

- [ ] Ensure the PKNCA dose variable is created using the mapped DOSE column name (from column mapping).

- [ ] No functional change for existing workflows where the dose amount column is already DOSEA

Definition of done, preferably copied from the issue.

## How to test

How to test features not covered by unit tests.

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] App or package changes are reflected in NEWS
- [ ] Package version is incremented

## Notes to reviewer

- Primary change is replacing direct "DOSEA" usage with the mapped dose column (data$dose$columns$dose) when constructing the PKNCAdose/PKNCAdata objects.

- Downstream code already uses pknca_data$dose$columns$dose in places (e.g., joins), so once the PKNCA dose column is set correctly, the rest of the workflow should behave the same.

- Backward compatibility is preserved for standard ADNCA inputs where the dose amount column is DOSEA.

Anything that the reviewer should know before tacking the pull request?
