### PR TITLE
Closes #875 add tests for format data to reach 100

### DIFF
--- a/tests/testthat/test-format_data.R
+++ b/tests/testthat/test-format_data.R
@@ -146,17 +146,17 @@ describe("format_pkncaconc_data", {
     test_df$NCA1XRS <- c(rep("Contaminated sample", 2), rep(NA_character_, nrows - 2))
     test_df$NCA2XRS <- c("Wrongly labelled", rep(NA_character_, nrows - 2), "Wrong labelled")
 
-    res <- format_pkncaconc_data(
-      test_df,
-      group_columns = "USUBJID",
-      nca_exclude_reason_columns = c("NCA1XRS", "NCA2XRS")
-    )
-
     exp_nca_exclude <- c(
       "Contaminated sample; Wrongly labelled",
       "Contaminated sample",
       rep("", nrows - 3),
       "Wrong labelled"
+    )
+
+    res <- format_pkncaconc_data(
+      test_df,
+      group_columns = "USUBJID",
+      nca_exclude_reason_columns = c("NCA1XRS", "NCA2XRS")
     )
 
     expect_equal(res$nca_exclude, exp_nca_exclude)


### PR DESCRIPTION
## Issue

Closes #875 

## Description

This PR adds new tests to the `format_pkncaconc_data`: 

* Added a test to verify that the function correctly handles the `time_end_column` (specifically `AEFRLT`) and computes the `CONCDUR` (collection duration) column as expected. Also confirmed that `CONCDUR` can be used as a sample collection duration in downstream PKNCA analysis.

* Introduced a test to check that multiple exclusion reason columns (`nca_exclude_reason_columns`) are concatenated correctly into the `nca_exclude` output column.



## Definition of Done

- [x] 100% coverage on `format_data.R` with `test-format_data.R`

## How to test

Check the new tests are logical and run `covr::file_coverage("R/format_data.R", "tests/testthat/test-format_data.R")` to check 100% coverage was reached.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- ~App or package changes are reflected in NEWS~
- ~Package version is incremented~

## Notes to reviewer
No notes to reviewer
