### PR TITLE
refactor: remove openxlsx2, replace with readxl and writexl (#1005)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9075
+Version: 0.1.0.9076
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),
@@ -65,8 +65,8 @@ Suggests:
     markdown,
     mockery,
     nestcolor,
-    openxlsx2,
     pak,
+    readxl,
     reactable,
     reactable.extras,
     rmarkdown,
@@ -83,6 +83,7 @@ Suggests:
     quarto,
     vdiffr,
     withr,
+    writexl,
     zip
 Config/testthat/edition: 3
 Language: en-US

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Features added
 
+* Replace openxlsx2 with readxl (reading) and writexl (writing) for xlsx file handling (#1005)
 * Export filenames use STUDYID as fallback when no project name is set, date suffix removed (#1000)
 * Project name auto-populated from STUDYID on data upload (#1000)
 * Enhancements to the slides outputs including grouping by PKNCA groups, dose profile, and additional grouping variables (#791)

--- a/R/readers.R
+++ b/R/readers.R
@@ -53,12 +53,12 @@ readers <- list(
   csv = function(path) read.csv(path, na = c("", "NA")),
   rds = function(path) readRDS(path),
   xlsx = function(path) {
-    if (!requireNamespace("openxlsx2", silently = TRUE))
+    if (!requireNamespace("readxl", quietly = TRUE))
       stop(
-        "Handling .xlsx files requires `openxlsx2` package, please install it with ",
-        "`install.packages('openxlsx2')`"
+        "Handling .xlsx files requires `readxl` package, please install it with ",
+        "`install.packages('readxl')`"
       )
-    openxlsx2::read_xlsx(path)
+    as.data.frame(readxl::read_xlsx(path))
   },
   sas7bdat = function(path) {
     if (!requireNamespace("haven", silently = TRUE))

--- a/inst/shiny/modules/common/reactable.R
+++ b/inst/shiny/modules/common/reactable.R
@@ -111,7 +111,7 @@ reactable_server <- function(
 
     output$download_xlsx <- downloadHandler(
       filename = .reactable_file_name(file_name, "xlsx", id),
-      content = function(con) openxlsx2::write_xlsx(labeled_data, con)
+      content = function(con) writexl::write_xlsx(labeled_data, con)
     )
 
     reactive(

--- a/tests/testthat/test-readers.R
+++ b/tests/testthat/test-readers.R
@@ -19,11 +19,12 @@ describe("read_pk", {
   })
 
   it("reads excel data correctly", {
-    skip_if_not_installed("openxlsx2")
+    skip_if_not_installed("readxl")
+    skip_if_not_installed("writexl")
     skip_on_cran()
 
     tmp_xlsx <- withr::local_tempfile(fileext = ".xlsx")
-    openxlsx2::write_xlsx(data_dummy, tmp_xlsx)
+    writexl::write_xlsx(data_dummy, tmp_xlsx)
 
     df <- read_pk(tmp_xlsx)
 


### PR DESCRIPTION
## Issue

Closes #1005

## Description

Removes all `openxlsx2` usage from the package and replaces it with `readxl` (reading) and `writexl` (writing). This allows removing `openxlsx2` from Suggests entirely.

### Changes

| File | Before | After |
|------|--------|-------|
| `R/readers.R` | `openxlsx2::read_xlsx(path)` | `as.data.frame(readxl::read_xlsx(path))` |
| `inst/shiny/modules/common/reactable.R` | `openxlsx2::write_xlsx(...)` | `writexl::write_xlsx(...)` |
| `tests/testthat/test-readers.R` | `openxlsx2::write_xlsx(...)` | `writexl::write_xlsx(...)` |
| `DESCRIPTION` | `openxlsx2` in Suggests | Replaced with `readxl` and `writexl` |

### Notes

- `readxl::read_xlsx` returns a tibble; wrapped in `as.data.frame()` to match the previous `openxlsx2` behavior.
- `requireNamespace` parameter fixed from `silently` (not a real parameter) to `quietly`.
- Both `readxl` and `writexl` are lighter dependencies than `openxlsx2` (no Java/system library requirements).

## How to test

1. Upload an `.xlsx` file in the Data tab — verify it loads correctly
2. In any reactable with download buttons, click the xlsx download — verify the file is valid
3. Run `devtools::test(filter = \"readers\")` — verify the xlsx test passes

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)