### PR TITLE
change BLQ call to nca_setup.R & perform calculations

### DIFF
--- a/R/PKNCA.R
+++ b/R/PKNCA.R
@@ -227,7 +227,8 @@ PKNCA_create_data_object <- function(adnca_data, nca_exclude_reason_columns = NU
 #' @importFrom purrr pmap
 #'
 #' @export
-PKNCA_update_data_object <- function( # nolint: object_name_linter
+PKNCA_update_data_object <- function(
+    # nolint: object_name_linter
     adnca_data,
     method,
     selected_analytes,
@@ -237,7 +238,6 @@ PKNCA_update_data_object <- function( # nolint: object_name_linter
     hl_adj_rules = NULL,
     exclusion_list = NULL,
     keep_interval_cols = NULL) {
-
   data <- adnca_data
   analyte_column <- data$conc$columns$groups$group_analyte
   unique_analytes <- unique(data$conc$data[[analyte_column]])
@@ -338,8 +338,12 @@ PKNCA_update_data_object <- function( # nolint: object_name_linter
 #' @export
 PKNCA_calculate_nca <- function(pknca_data, blq_rule = NULL) { # nolint: object_name_linter
 
-  # Define BLQ imputation method in global environment for PKNCA to access
-  if (!is.null(blq_rule)) {
+  blq_already_defined <- exists(
+    "PKNCA_impute_method_blq",
+    envir = as.environment(1), inherits = FALSE
+  )
+
+  if (!is.null(blq_rule) && !blq_already_defined) {
     .assign_global(
       "PKNCA_impute_method_blq", # nolint
       function(conc, time, ...) { # nolint
@@ -365,17 +369,17 @@ PKNCA_calculate_nca <- function(pknca_data, blq_rule = NULL) { # nolint: object_
           arrange(time)
       }
     )
-  }
 
-  # Ensure removal of the global PKNCA_impute_method_blq once NCA is run to avoid side effects
-  on.exit(
-    {
-      if (exists("PKNCA_impute_method_blq", envir = as.environment(1), inherits = FALSE)) {
-        rm("PKNCA_impute_method_blq", envir = as.environment(1))
-      }
-    },
-    add = TRUE
-  )
+    # Only clean up if we created it ourselves (standalone / test usage)
+    on.exit(
+      {
+        if (exists("PKNCA_impute_method_blq", envir = as.environment(1), inherits = FALSE)) {
+          rm("PKNCA_impute_method_blq", envir = as.environment(1))
+        }
+      },
+      add = TRUE
+    )
+  }
 
   # Calculate results using PKNCA
   results <- PKNCA::pk.nca(data = pknca_data, verbose = FALSE)
@@ -753,7 +757,6 @@ PKNCA_hl_rules_exclusion <- function(res, rules) { # nolint
 #' # Suppose processed_pknca_data is a valid PKNCA data object
 #' # check_valid_pknca_data(processed_pknca_data)
 check_valid_pknca_data <- function(processed_pknca_data, check_exclusion_has_reason = TRUE) {
-
   if (check_exclusion_has_reason) {
     excl_hl_col <- processed_pknca_data$conc$columns$exclude_half.life
 

--- a/R/intervals.R
+++ b/R/intervals.R
@@ -119,9 +119,10 @@ format_pkncadata_intervals <- function(pknca_conc,
     ungroup() %>%
     # Remove scientifically invalid intervals where start > end
     filter(start <= end) %>%
-    select(any_of(c("start", "end", conc_groups,
-                    "ATPTREF", "DOSNOA", "VOLUME", keep_interval_cols))) %>%
-
+    select(any_of(c(
+      "start", "end", conc_groups,
+      "ATPTREF", "DOSNOA", "VOLUME", keep_interval_cols
+    ))) %>%
     # Create logical columns with only TRUE for the NCA parameters requested by the user
     mutate(!!!setNames(rep(FALSE, length(params)), params)) %>%
     # Identify the intervals as the base ones for the NCA analysis
@@ -147,12 +148,11 @@ format_pkncadata_intervals <- function(pknca_conc,
 #' @returns An updated PKNCAdata object with parameter intervals based on user selections.
 #' @export
 update_main_intervals <- function(
-  data,
-  parameter_selections,
-  study_types_df, int_parameters,
-  impute = TRUE,
-  blq_imputation_rule = NULL
-) {
+    data,
+    parameter_selections,
+    study_types_df, int_parameters,
+    impute = TRUE,
+    blq_imputation_rule = NULL) {
   all_pknca_params <- setdiff(names(PKNCA::get.interval.cols()), c("start", "end"))
 
   # Determine the grouping columns from the study_types_df
@@ -255,10 +255,16 @@ rm_impute_obs_params <- function(data, metadata_nca_parameters = metadata_nca_pa
     filter(grepl("auc|aumc", PKNCA) | grepl("auc", Depends)) %>%
     pull(PKNCA)
 
+  # Half-life category parameters should keep imputation (blq + start_conc)
+  params_halflife <- metadata_nca_parameters %>%
+    filter(CAT == "Half-life") %>%
+    pull(PKNCA)
+
   params_not_to_impute <- metadata_nca_parameters %>%
     filter(
       !grepl("auc|aumc", PKNCA),
-      !grepl(paste0(params_auc_dep, collapse = "|"), Depends)
+      !grepl(paste0(params_auc_dep, collapse = "|"), Depends),
+      !PKNCA %in% params_halflife
     ) %>%
     pull(PKNCA) %>%
     intersect(names(PKNCA::get.interval.cols()))

--- a/inst/shiny/modules/tab_nca/nca_setup.R
+++ b/inst/shiny/modules/tab_nca/nca_setup.R
@@ -44,7 +44,6 @@ nca_setup_ui <- function(id) {
 
 nca_setup_server <- function(id, data, adnca_data, extra_group_vars, settings_override) {
   moduleServer(id, function(input, output, session) {
-
     imported_settings <- reactive(settings_override()$settings)
     imported_slopes <- reactive(settings_override()$slope_rules)
     imported_params <- reactive(imported_settings()$parameters$selections)
@@ -89,7 +88,6 @@ nca_setup_server <- function(id, data, adnca_data, extra_group_vars, settings_ov
     )
 
     final_settings <- reactive({
-
       req(settings(), parameters_output$selections(), general_exclusions())
 
       current_settings <- settings()
@@ -103,8 +101,10 @@ nca_setup_server <- function(id, data, adnca_data, extra_group_vars, settings_ov
 
     # Update pknca data object and intervals using summary output
     processed_pknca_data <- reactive({
-      req(adnca_data(), settings(),
-          parameters_output$selections(), parameters_output$types_df())
+      req(
+        adnca_data(), settings(),
+        parameters_output$selections(), parameters_output$types_df()
+      )
 
       log_trace("Updating PKNCA::data object.")
 
@@ -189,6 +189,35 @@ nca_setup_server <- function(id, data, adnca_data, extra_group_vars, settings_ov
 
     # Parameter unit changes option: Opens a modal message with a units table to edit
     units_table_server("units_table", processed_pknca_data)
+
+    # Keep PKNCA_impute_method_blq in the global env in sync with the BLQ setting.
+    # Both PKNCA_calculate_nca() and the slope selector's pk.nca() calls rely on it.
+    observe({
+      blq_rule <- settings()$data_imputation$blq_imputation_rule
+      if (!is.null(blq_rule)) {
+        .assign_global(
+          "PKNCA_impute_method_blq", # nolint
+          function(conc, time, ...) { # nolint
+            d <- PKNCA::clean.conc.blq(
+              conc = conc,
+              time = time,
+              conc.blq = blq_rule,
+              conc.na = "drop"
+            )
+            d_na <- data.frame(
+              conc = rep(NA, sum(!time %in% d$time)),
+              time = time[!time %in% d$time]
+            )
+            rbind(d, d_na) %>%
+              dplyr::arrange(time)
+          }
+        )
+      } else {
+        if (exists("PKNCA_impute_method_blq", envir = as.environment(1), inherits = FALSE)) {
+          rm("PKNCA_impute_method_blq", envir = as.environment(1))
+        }
+      }
+    })
 
     # Collect all half life manual adjustments done in the `Slope Selector` section
     # and controls the half life plots that are displayed


### PR DESCRIPTION
## Issue

Closes #1057

## Description

This pull request introduces several improvements and bug fixes to the PKNCA data processing pipeline, focusing on better handling of BLQ (Below Limit of Quantification) imputation, exclusion logic, and interval formatting. The changes enhance robustness and maintainability, especially regarding global environment side effects and parameter imputation rules.

* Improved BLQ imputation logic in `PKNCA_calculate_nca` to avoid unintended side effects by only assigning the BLQ method globally if it is not already defined, and cleaning up after execution only if necessary. 
* Added a Shiny observer in `nca_setup_server` to keep the global `PKNCA_impute_method_blq` in sync with the user's BLQ setting, ensuring consistent behavior across both NCA calculations and slope selector operations.
* Updated `rm_impute_obs_params` to ensure half-life category parameters retain imputation, while other parameters are properly filtered, improving scientific validity and preventing incorrect exclusions.
* Refactored `format_pkncadata_intervals` and related code to improve readability and maintainability, including formatting the `select` statement and fixing function signatures for clarity and consistency.
* Removed unnecessary blank lines and improved formatting in several functions for better code hygiene and readability.


## Definition of Done



## How to test

How to test features not covered by unit tests.

## Contributor checklist
- [ ] Code passes lintr checks
- [x] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] App or package changes are reflected in NEWS
- [ ] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)

## Notes to reviewer

Anything that the reviewer should know before tacking the pull request?
