### PR TITLE
feat: persist PP exclusions in settings YAML download and upload

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9114
+Version: 0.1.0.9115
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Features added
 
+* PP exclusions (PPSUM1F/PPSUM1R) are now included in settings YAML download and restored on upload (#1110)
 * Parameter Exclusions: exclude individual PK parameter rows from descriptive statistics and ADPP export via PPSUM1F/PPSUM1R flags (#1040)
 * Ratio calculations table is now included in settings YAML export and restored on upload, with validation against available parameters and groups (#1091)
 * Data tab filters are now included in the settings YAML file and restored on upload, for both standalone settings download and ZIP export (#1082)

--- a/inst/shiny/functions/exclusion-utils.R
+++ b/inst/shiny/functions/exclusion-utils.R
@@ -1,0 +1,58 @@
+# Shared utilities for exclusion list management.
+# Used by both general_exclusions.R and parameter_exclusions.R.
+
+#' Rehydrate an exclusion override list with fresh button IDs.
+#'
+#' Uploaded settings store exclusions without xbtn_id. This function
+#' assigns new IDs so the remove buttons work in the current session.
+#'
+#' @param overrides List of exclusion entries (reason + rows, no xbtn_id).
+#' @param exclusion_list ReactiveVal holding the current exclusion list.
+#' @param xbtn_counter ReactiveVal holding the button ID counter.
+#' @param prefix Character prefix for button IDs.
+rehydrate_exclusions <- function(overrides, exclusion_list, xbtn_counter, prefix) {
+  new_ids <- seq_along(overrides) + xbtn_counter()
+  rehydrated <- purrr::map2(overrides, new_ids, function(item, id) {
+    item$xbtn_id <- paste0(prefix, id)
+    item
+  })
+  xbtn_counter(max(new_ids))
+  exclusion_list(rehydrated)
+}
+
+#' Strip xbtn_id from an exclusion list for persistence.
+#'
+#' @param lst List of exclusion entries (with xbtn_id).
+#' @returns List of exclusion entries without xbtn_id.
+clean_exclusion_list <- function(lst) {
+  lapply(lst, function(x) x[setdiff(names(x), "xbtn_id")])
+}
+
+#' Register remove-button observers for exclusion list entries.
+#'
+#' Each entry's xbtn_id is observed once. When clicked, the entry is
+#' removed from the exclusion list. Already-registered IDs are skipped.
+#'
+#' @param exclusion_list ReactiveVal holding the current exclusion list.
+#' @param registered_ids ReactiveVal(character) tracking registered button IDs.
+#' @param input Shiny input object.
+observe_remove_buttons <- function(exclusion_list, registered_ids, input) {
+  observe({
+    lst <- exclusion_list()
+    already <- registered_ids()
+    new_ids <- setdiff(
+      vapply(lst, function(x) x$xbtn_id, character(1)),
+      already
+    )
+    for (xbtn_id in new_ids) {
+      local({
+        local_id <- xbtn_id
+        observeEvent(input[[local_id]], {
+          current <- exclusion_list()
+          exclusion_list(Filter(function(x) x$xbtn_id != local_id, current))
+        }, ignoreInit = TRUE, once = TRUE)
+      })
+    }
+    registered_ids(union(already, new_ids))
+  })
+}

--- a/inst/shiny/functions/zip-utils.R
+++ b/inst/shiny/functions/zip-utils.R
@@ -451,6 +451,7 @@ prepare_export_files <- function(target_dir,
   }
 
   settings_list$ratio_table <- session$userData$ratio_table()
+  settings_list$param_exclusions <- session$userData$param_exclusions()
 
   settings_to_save <- list(
     filters = session$userData$applied_filters,

--- a/inst/shiny/modules/tab_nca.R
+++ b/inst/shiny/modules/tab_nca.R
@@ -213,16 +213,19 @@ tab_nca_server <- function(id, pknca_data, extra_group_vars, settings_override) 
 
     # Parameter exclusions: users can exclude individual PK parameter rows
     # from summary tables and mean plots. Excluded rows get PPSUM1F = "1" in ADPP.
-    param_excl_rows <- parameter_exclusions_server(
-      "parameter_exclusions", res_nca
+    param_excl_override <- reactive(settings_override()$settings$param_exclusions)
+    param_exclusions <- parameter_exclusions_server(
+      "parameter_exclusions", res_nca, param_excl_override
     )
+    # Store the exclusion list for settings download/ZIP export
+    session$userData$param_exclusions <- param_exclusions
 
     # Compute tagged and filtered views of res_nca in a single reactive
     # to avoid duplicating the (potentially large) result object.
     res_nca_excl <- reactive({
       req(res_nca())
       res <- res_nca()
-      excl_info <- param_excl_rows()
+      excl_info <- .build_exclusion_reasons(param_exclusions())
       excl_indices <- excl_info$indices
       excl_reasons <- excl_info$reasons
 

--- a/inst/shiny/modules/tab_nca/nca_setup.R
+++ b/inst/shiny/modules/tab_nca/nca_setup.R
@@ -212,6 +212,7 @@ nca_setup_server <- function(id, data, adnca_data, extra_group_vars, settings_ov
             dplyr::select(-default)
         }
         export_settings$ratio_table <- ratio_table()
+        export_settings$param_exclusions <- session$userData$param_exclusions()
         settings_to_save <- list(
           filters = session$userData$applied_filters,
           settings = export_settings,

--- a/inst/shiny/modules/tab_nca/setup/parameter_exclusions.R
+++ b/inst/shiny/modules/tab_nca/setup/parameter_exclusions.R
@@ -131,7 +131,7 @@ parameter_exclusions_ui <- function(id) {
   )
 }
 
-parameter_exclusions_server <- function(id, res_nca) {
+parameter_exclusions_server <- function(id, res_nca, param_excl_override) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 
@@ -139,7 +139,7 @@ parameter_exclusions_server <- function(id, res_nca) {
     xbtn_counter <- reactiveVal(0)
     prev_fingerprint <- reactiveVal(NULL)
 
-    # Clear exclusions only when result structure changes (row count or columns),
+    # Clear exclusions when result structure changes (row count or columns),
     # not on every recomputation (e.g. unit changes that preserve row identity).
     observeEvent(res_nca(), {
       res <- res_nca()$result
@@ -148,6 +148,15 @@ parameter_exclusions_server <- function(id, res_nca) {
         exclusion_list(list())
         xbtn_counter(0)
         prev_fingerprint(fp)
+      }
+    })
+
+    # Restore exclusions from uploaded settings
+    observeEvent(param_excl_override(), {
+      overrides <- param_excl_override()
+      if (!is.null(overrides) && length(overrides) > 0) {
+        rehydrate_exclusions(overrides, exclusion_list, xbtn_counter,
+                             prefix = "remove_param_excl_")
       }
     })
 
@@ -217,28 +226,9 @@ parameter_exclusions_server <- function(id, res_nca) {
       }
     })
 
-    # Track which remove buttons already have observers to avoid duplicates
+    # Register remove-button observers for exclusion entries
     registered_xbtns <- reactiveVal(character(0))
-
-    # Register observers only for new remove buttons
-    observe({
-      lst <- exclusion_list()
-      already <- registered_xbtns()
-      new_ids <- setdiff(
-        vapply(lst, function(x) x$xbtn_id, character(1)),
-        already
-      )
-      for (xbtn_id in new_ids) {
-        local({
-          local_id <- xbtn_id
-          observeEvent(input[[local_id]], {
-            current <- exclusion_list()
-            exclusion_list(Filter(function(x) x$xbtn_id != local_id, current))
-          }, ignoreInit = TRUE, once = TRUE)
-        })
-      }
-      registered_xbtns(union(already, new_ids))
-    })
+    observe_remove_buttons(exclusion_list, registered_xbtns, input)
 
     output$exclusion_list_ui <- renderUI({
       tbl <- .render_exclusion_table(exclusion_list(), ns)
@@ -249,6 +239,7 @@ parameter_exclusions_server <- function(id, res_nca) {
       )
     })
 
-    reactive(.build_exclusion_reasons(exclusion_list()))
+    # Return the exclusion list without xbtn_id (same pattern as general_exclusions)
+    reactive(clean_exclusion_list(exclusion_list()))
   })
 }

--- a/inst/shiny/modules/tab_nca/setup/parameter_exclusions.R
+++ b/inst/shiny/modules/tab_nca/setup/parameter_exclusions.R
@@ -84,6 +84,47 @@ parameter_exclusions_ui <- function(id) {
   list(indices = all_indices, reasons = reasons[all_indices])
 }
 
+# Columns used to identify excluded rows across NCA runs.
+.get_excl_key_cols <- function(res_nca) {
+  group_cols <- unname(unlist(res_nca$data$conc$columns$groups))
+  unique(c(group_cols, "PPTESTCD", "PPORRES"))
+}
+
+# Extract key columns from result rows at given indices.
+.extract_row_keys <- function(result_df, row_indices, key_cols) {
+  available <- intersect(key_cols, names(result_df))
+  result_df[row_indices, available, drop = FALSE]
+}
+
+# Match key rows against a result data frame.
+# Returns a list with `matched` (row indices) and `unmatched` (key data frame rows).
+.match_keys_to_rows <- function(keys_df, result_df) {
+  available <- intersect(names(keys_df), names(result_df))
+  if (length(available) == 0) {
+    return(list(matched = integer(0), unmatched = keys_df))
+  }
+  matched <- integer(0)
+  unmatched_idx <- integer(0)
+  for (i in seq_len(nrow(keys_df))) {
+    key_row <- keys_df[i, available, drop = FALSE]
+    # Find rows in result_df that match all key columns
+    match_mask <- rep(TRUE, nrow(result_df))
+    for (col in available) {
+      match_mask <- match_mask & (as.character(result_df[[col]]) == as.character(key_row[[col]]))
+    }
+    hits <- which(match_mask)
+    if (length(hits) > 0) {
+      matched <- c(matched, hits[1])
+    } else {
+      unmatched_idx <- c(unmatched_idx, i)
+    }
+  }
+  list(
+    matched = matched,
+    unmatched = if (length(unmatched_idx) > 0) keys_df[unmatched_idx, , drop = FALSE] else NULL
+  )
+}
+
 # Render the exclusion list as a reactable with remove buttons.
 .render_exclusion_table <- function(lst, ns) {
   if (length(lst) == 0) return(NULL)
@@ -214,11 +255,15 @@ parameter_exclusions_server <- function(id, res_nca, param_excl_override) {
       rows_sel <- param_table_state()$selected
       reason <- input$exclusion_reason
       if (length(rows_sel) > 0 && nzchar(reason)) {
+        result_df <- res_nca()$result
+        key_cols <- .get_excl_key_cols(res_nca())
+        keys <- .extract_row_keys(result_df, rows_sel, key_cols)
+
         current <- exclusion_list()
         xbtn_id <- paste0("remove_param_excl_", xbtn_counter() + 1)
         xbtn_counter(xbtn_counter() + 1)
         new_entry <- list(list(
-          reason = reason, rows = rows_sel, xbtn_id = xbtn_id
+          reason = reason, rows = rows_sel, keys = keys, xbtn_id = xbtn_id
         ))
         exclusion_list(append(current, new_entry))
         updateTextInput(session, "exclusion_reason", value = "")
@@ -239,7 +284,13 @@ parameter_exclusions_server <- function(id, res_nca, param_excl_override) {
       )
     })
 
-    # Return the exclusion list without xbtn_id (same pattern as general_exclusions)
-    reactive(clean_exclusion_list(exclusion_list()))
+    # Return the exclusion list for persistence.
+    # Strip xbtn_id (session-only) and rows (ephemeral indices).
+    # Only reason + keys are persisted to YAML.
+    reactive({
+      lapply(exclusion_list(), function(x) {
+        x[intersect(names(x), c("reason", "keys"))]
+      })
+    })
   })
 }

--- a/inst/shiny/modules/tab_nca/setup/parameter_exclusions.R
+++ b/inst/shiny/modules/tab_nca/setup/parameter_exclusions.R
@@ -46,6 +46,7 @@ parameter_exclusions_ui <- function(id) {
         status = "primary"
       )
     ),
+    uiOutput(ns("restore_warning_ui")),
     uiOutput(ns("exclusion_list_ui")),
     div(
       class = "results-legend",
@@ -342,6 +343,21 @@ parameter_exclusions_server <- function(id, res_nca, param_excl_override) {
     # Register remove-button observers for exclusion entries
     registered_xbtns <- reactiveVal(character(0))
     observe_remove_buttons(exclusion_list, registered_xbtns, input)
+
+    output$restore_warning_ui <- renderUI({
+      msg <- restore_warnings()
+      if (is.null(msg)) return(NULL)
+      div(
+        class = "alert alert-warning alert-dismissible",
+        role = "alert",
+        tags$button(
+          type = "button", class = "btn-close",
+          `data-bs-dismiss` = "alert", `aria-label` = "Close"
+        ),
+        tags$strong("Settings restore: "),
+        lapply(strsplit(msg, "\n")[[1]], function(line) tags$div(line))
+      )
+    })
 
     output$exclusion_list_ui <- renderUI({
       tbl <- .render_exclusion_table(exclusion_list(), ns)

--- a/inst/shiny/modules/tab_nca/setup/parameter_exclusions.R
+++ b/inst/shiny/modules/tab_nca/setup/parameter_exclusions.R
@@ -125,6 +125,63 @@ parameter_exclusions_ui <- function(id) {
   )
 }
 
+# Restore exclusions from uploaded settings by matching keys against current results.
+# Matched entries are added to the exclusion list with resolved row indices.
+# Unmatched entries produce a warning message stored in restore_warnings.
+.restore_exclusions_from_keys <- function(overrides, res_nca_val, exclusion_list,
+                                          xbtn_counter, restore_warnings) {
+  result_df <- res_nca_val$result
+  key_cols <- .get_excl_key_cols(res_nca_val)
+  all_unmatched <- list()
+  restored <- list()
+
+  for (entry in overrides) {
+    keys_df <- entry$keys
+    if (is.null(keys_df) || !is.data.frame(keys_df) || nrow(keys_df) == 0) next
+
+    match_result <- .match_keys_to_rows(keys_df, result_df)
+
+    if (length(match_result$matched) > 0) {
+      counter_val <- xbtn_counter() + length(restored) + 1L
+      restored <- append(restored, list(list(
+        reason = entry$reason,
+        rows = match_result$matched,
+        keys = .extract_row_keys(result_df, match_result$matched, key_cols),
+        xbtn_id = paste0("remove_param_excl_", counter_val)
+      )))
+    }
+
+    if (!is.null(match_result$unmatched)) {
+      all_unmatched <- append(all_unmatched, list(list(
+        reason = entry$reason,
+        keys = match_result$unmatched
+      )))
+    }
+  }
+
+  if (length(restored) > 0) {
+    xbtn_counter(xbtn_counter() + length(restored))
+    exclusion_list(restored)
+  }
+
+  if (length(all_unmatched) > 0) {
+    msgs <- vapply(all_unmatched, function(u) {
+      key_desc <- paste(
+        apply(u$keys, 1, function(r) paste(names(u$keys), "=", r, collapse = ", ")),
+        collapse = "; "
+      )
+      paste0("\"", u$reason, "\": ", key_desc)
+    }, character(1))
+    restore_warnings(paste(
+      "Some exclusions from settings could not be restored",
+      "(values may have changed):\n",
+      paste("-", msgs, collapse = "\n")
+    ))
+  } else {
+    restore_warnings(NULL)
+  }
+}
+
 # Render the exclusion list as a reactable with remove buttons.
 .render_exclusion_table <- function(lst, ns) {
   if (length(lst) == 0) return(NULL)
@@ -179,9 +236,12 @@ parameter_exclusions_server <- function(id, res_nca, param_excl_override) {
     exclusion_list <- reactiveVal(list())
     xbtn_counter <- reactiveVal(0)
     prev_fingerprint <- reactiveVal(NULL)
+    pending_override <- reactiveVal(NULL)
+    restore_warnings <- reactiveVal(NULL)
 
     # Clear exclusions when result structure changes (row count or columns),
     # not on every recomputation (e.g. unit changes that preserve row identity).
+    # After clearing, apply any pending override from uploaded settings.
     observeEvent(res_nca(), {
       res <- res_nca()$result
       fp <- paste(nrow(res), paste(names(res), collapse = ","))
@@ -189,15 +249,23 @@ parameter_exclusions_server <- function(id, res_nca, param_excl_override) {
         exclusion_list(list())
         xbtn_counter(0)
         prev_fingerprint(fp)
+
+        overrides <- pending_override()
+        if (!is.null(overrides) && length(overrides) > 0) {
+          .restore_exclusions_from_keys(
+            overrides, res_nca(), exclusion_list, xbtn_counter, restore_warnings
+          )
+          pending_override(NULL)
+        }
       }
     })
 
-    # Restore exclusions from uploaded settings
+    # Queue uploaded exclusions for application after NCA results are ready.
     observeEvent(param_excl_override(), {
       overrides <- param_excl_override()
       if (!is.null(overrides) && length(overrides) > 0) {
-        rehydrate_exclusions(overrides, exclusion_list, xbtn_counter,
-                             prefix = "remove_param_excl_")
+        restore_warnings(NULL)
+        pending_override(overrides)
       }
     })
 

--- a/tests/testthat/test-parameter_exclusions.R
+++ b/tests/testthat/test-parameter_exclusions.R
@@ -14,6 +14,22 @@ source(
   local = TRUE
 )
 
+# --- Helper data for key-based tests ---
+mock_result_df <- data.frame(
+  USUBJID = c("SUBJ-01", "SUBJ-01", "SUBJ-02", "SUBJ-02"),
+  PPTESTCD = c("AUCLST", "CMAX", "AUCLST", "CMAX"),
+  PPORRES = c("100.5", "25.3", "98.2", "22.1"),
+  PARAM = c("Analyte A", "Analyte A", "Analyte A", "Analyte A"),
+  stringsAsFactors = FALSE
+)
+
+mock_res_nca <- list(
+  result = mock_result_df,
+  data = list(conc = list(columns = list(groups = list(
+    group_subject = "USUBJID"
+  ))))
+)
+
 describe(".build_exclusion_reasons", {
   it("returns empty indices and reasons for an empty list", {
     result <- .build_exclusion_reasons(list())
@@ -40,18 +56,163 @@ describe(".build_exclusion_reasons", {
     expect_equal(result$reasons[2], "Outlier; Protocol deviation")
     expect_equal(result$reasons[3], "Protocol deviation")
   })
+})
 
-  it("handles non-contiguous row indices", {
-    lst <- list(
-      list(reason = "Bad sample", rows = c(5L, 10L))
-    )
-    result <- .build_exclusion_reasons(lst)
-    expect_equal(result$indices, c(5L, 10L))
-    expect_equal(result$reasons, c("Bad sample", "Bad sample"))
+describe(".get_excl_key_cols", {
+  it("returns grouping columns plus PPTESTCD and PPORRES", {
+    cols <- .get_excl_key_cols(mock_res_nca)
+    expect_true("USUBJID" %in% cols)
+    expect_true("PPTESTCD" %in% cols)
+    expect_true("PPORRES" %in% cols)
   })
 })
 
-describe("rehydrate_exclusions", {
+describe(".extract_row_keys", {
+  it("extracts key columns for given row indices", {
+    key_cols <- c("USUBJID", "PPTESTCD", "PPORRES")
+    keys <- .extract_row_keys(mock_result_df, c(1L, 3L), key_cols)
+    expect_equal(nrow(keys), 2)
+    expect_equal(keys$USUBJID, c("SUBJ-01", "SUBJ-02"))
+    expect_equal(keys$PPTESTCD, c("AUCLST", "AUCLST"))
+    expect_equal(keys$PPORRES, c("100.5", "98.2"))
+  })
+
+  it("ignores key columns not present in the data", {
+    keys <- .extract_row_keys(mock_result_df, 1L, c("USUBJID", "NONEXISTENT"))
+    expect_equal(names(keys), "USUBJID")
+  })
+})
+
+describe(".match_keys_to_rows", {
+  it("matches keys that exist in the result", {
+    keys_df <- data.frame(
+      USUBJID = "SUBJ-01", PPTESTCD = "CMAX", PPORRES = "25.3",
+      stringsAsFactors = FALSE
+    )
+    result <- .match_keys_to_rows(keys_df, mock_result_df)
+    expect_equal(result$matched, 2L)
+    expect_null(result$unmatched)
+  })
+
+  it("returns unmatched keys when PPORRES differs", {
+    keys_df <- data.frame(
+      USUBJID = "SUBJ-01", PPTESTCD = "CMAX", PPORRES = "999.9",
+      stringsAsFactors = FALSE
+    )
+    result <- .match_keys_to_rows(keys_df, mock_result_df)
+    expect_equal(result$matched, integer(0))
+    expect_equal(nrow(result$unmatched), 1)
+  })
+
+  it("handles a mix of matched and unmatched keys", {
+    keys_df <- data.frame(
+      USUBJID = c("SUBJ-01", "SUBJ-02"),
+      PPTESTCD = c("AUCLST", "CMAX"),
+      PPORRES = c("100.5", "999.9"),
+      stringsAsFactors = FALSE
+    )
+    result <- .match_keys_to_rows(keys_df, mock_result_df)
+    expect_equal(result$matched, 1L)
+    expect_equal(nrow(result$unmatched), 1)
+    expect_equal(result$unmatched$PPORRES, "999.9")
+  })
+
+  it("returns all unmatched when no keys match", {
+    keys_df <- data.frame(
+      USUBJID = "SUBJ-99", PPTESTCD = "AUCLST", PPORRES = "0",
+      stringsAsFactors = FALSE
+    )
+    result <- .match_keys_to_rows(keys_df, mock_result_df)
+    expect_equal(result$matched, integer(0))
+    expect_equal(nrow(result$unmatched), 1)
+  })
+})
+
+describe(".restore_exclusions_from_keys", {
+  it("restores matched exclusions and sets row indices", {
+    excl_list <- shiny::reactiveVal(list())
+    counter <- shiny::reactiveVal(0L)
+    warnings <- shiny::reactiveVal(NULL)
+
+    overrides <- list(
+      list(
+        reason = "Outlier",
+        keys = data.frame(
+          USUBJID = c("SUBJ-01", "SUBJ-02"),
+          PPTESTCD = c("AUCLST", "AUCLST"),
+          PPORRES = c("100.5", "98.2"),
+          stringsAsFactors = FALSE
+        )
+      )
+    )
+
+    shiny::isolate({
+      .restore_exclusions_from_keys(
+        overrides, mock_res_nca, excl_list, counter, warnings
+      )
+      result <- excl_list()
+      expect_length(result, 1)
+      expect_equal(result[[1]]$reason, "Outlier")
+      expect_equal(sort(result[[1]]$rows), c(1L, 3L))
+      expect_null(warnings())
+    })
+  })
+
+  it("warns about unmatched keys and restores only matched ones", {
+    excl_list <- shiny::reactiveVal(list())
+    counter <- shiny::reactiveVal(0L)
+    warnings <- shiny::reactiveVal(NULL)
+
+    overrides <- list(
+      list(
+        reason = "Changed value",
+        keys = data.frame(
+          USUBJID = c("SUBJ-01", "SUBJ-01"),
+          PPTESTCD = c("AUCLST", "CMAX"),
+          PPORRES = c("100.5", "999.9"),
+          stringsAsFactors = FALSE
+        )
+      )
+    )
+
+    shiny::isolate({
+      .restore_exclusions_from_keys(
+        overrides, mock_res_nca, excl_list, counter, warnings
+      )
+      result <- excl_list()
+      expect_length(result, 1)
+      expect_equal(result[[1]]$rows, 1L)
+      expect_true(!is.null(warnings()))
+      expect_true(grepl("999.9", warnings()))
+    })
+  })
+
+  it("produces no exclusions when all keys are unmatched", {
+    excl_list <- shiny::reactiveVal(list())
+    counter <- shiny::reactiveVal(0L)
+    warnings <- shiny::reactiveVal(NULL)
+
+    overrides <- list(
+      list(
+        reason = "All gone",
+        keys = data.frame(
+          USUBJID = "SUBJ-99", PPTESTCD = "AUCLST", PPORRES = "0",
+          stringsAsFactors = FALSE
+        )
+      )
+    )
+
+    shiny::isolate({
+      .restore_exclusions_from_keys(
+        overrides, mock_res_nca, excl_list, counter, warnings
+      )
+      expect_length(excl_list(), 0)
+      expect_true(!is.null(warnings()))
+    })
+  })
+})
+
+describe("rehydrate_exclusions (general exclusions pattern)", {
   it("rehydrates overrides with fresh button IDs", {
     excl_list <- shiny::reactiveVal(list())
     counter <- shiny::reactiveVal(0L)
@@ -63,102 +224,31 @@ describe("rehydrate_exclusions", {
 
     shiny::isolate({
       rehydrate_exclusions(overrides, excl_list, counter,
-                           prefix = "remove_param_excl_")
-
+                           prefix = "remove_exclusion_reason_")
       result <- excl_list()
       expect_length(result, 2)
-      expect_equal(result[[1]]$reason, "Outlier")
-      expect_equal(result[[1]]$rows, c(1L, 3L))
-      expect_equal(result[[1]]$xbtn_id, "remove_param_excl_1")
-      expect_equal(result[[2]]$reason, "Protocol deviation")
-      expect_equal(result[[2]]$rows, 2L)
-      expect_equal(result[[2]]$xbtn_id, "remove_param_excl_2")
-      expect_equal(counter(), 2L)
-    })
-  })
-
-  it("continues counter from existing value", {
-    excl_list <- shiny::reactiveVal(list())
-    counter <- shiny::reactiveVal(5L)
-
-    overrides <- list(
-      list(reason = "Reason A", rows = c(1L))
-    )
-
-    shiny::isolate({
-      rehydrate_exclusions(overrides, excl_list, counter,
-                           prefix = "remove_param_excl_")
-
-      result <- excl_list()
-      expect_equal(result[[1]]$xbtn_id, "remove_param_excl_6")
-      expect_equal(counter(), 6L)
-    })
-  })
-
-  it("works with different prefixes", {
-    excl_list <- shiny::reactiveVal(list())
-    counter <- shiny::reactiveVal(0L)
-
-    overrides <- list(
-      list(reason = "Test", rows = c(1L))
-    )
-
-    shiny::isolate({
-      rehydrate_exclusions(overrides, excl_list, counter,
-                           prefix = "remove_exclusion_reason_")
-
-      result <- excl_list()
       expect_equal(result[[1]]$xbtn_id, "remove_exclusion_reason_1")
+      expect_equal(result[[2]]$xbtn_id, "remove_exclusion_reason_2")
+      expect_equal(counter(), 2L)
     })
   })
 })
 
 describe("clean_exclusion_list", {
-  it("strips xbtn_id and preserves reason and rows", {
+  it("strips xbtn_id and preserves other fields", {
     raw_list <- list(
-      list(reason = "Outlier", rows = c(1L, 3L), xbtn_id = "remove_param_excl_1"),
-      list(reason = "PD", rows = c(2L), xbtn_id = "remove_param_excl_2")
+      list(reason = "Outlier", rows = c(1L, 3L), xbtn_id = "x_1"),
+      list(reason = "PD", rows = c(2L), xbtn_id = "x_2")
     )
     clean <- clean_exclusion_list(raw_list)
 
     expect_length(clean, 2)
     expect_null(clean[[1]]$xbtn_id)
-    expect_null(clean[[2]]$xbtn_id)
     expect_equal(clean[[1]]$reason, "Outlier")
     expect_equal(clean[[1]]$rows, c(1L, 3L))
-    expect_equal(clean[[2]]$reason, "PD")
   })
 
   it("returns empty list for empty input", {
     expect_equal(clean_exclusion_list(list()), list())
-  })
-})
-
-describe("exclusion list round-trip", {
-  it("clean → rehydrate → build_reasons preserves data", {
-    raw_list <- list(
-      list(reason = "Outlier", rows = c(1L, 3L), xbtn_id = "remove_param_excl_1"),
-      list(reason = "PD", rows = c(2L), xbtn_id = "remove_param_excl_2")
-    )
-    clean <- clean_exclusion_list(raw_list)
-
-    excl_list <- shiny::reactiveVal(list())
-    counter <- shiny::reactiveVal(0L)
-
-    shiny::isolate({
-      rehydrate_exclusions(clean, excl_list, counter,
-                           prefix = "remove_param_excl_")
-      result <- excl_list()
-      expect_length(result, 2)
-      expect_equal(result[[1]]$reason, "Outlier")
-      expect_equal(result[[1]]$rows, c(1L, 3L))
-      expect_true(!is.null(result[[1]]$xbtn_id))
-
-      info <- .build_exclusion_reasons(result)
-      expect_equal(info$indices, c(1L, 2L, 3L))
-      expect_equal(info$reasons[1], "Outlier")
-      expect_equal(info$reasons[2], "PD")
-      expect_equal(info$reasons[3], "Outlier")
-    })
   })
 })

--- a/tests/testthat/test-parameter_exclusions.R
+++ b/tests/testthat/test-parameter_exclusions.R
@@ -1,0 +1,164 @@
+# Source the shared exclusion utilities and the parameter exclusions module
+source(
+  file.path(
+    system.file("shiny", package = "aNCA"),
+    "functions", "exclusion-utils.R"
+  ),
+  local = TRUE
+)
+source(
+  file.path(
+    system.file("shiny", package = "aNCA"),
+    "modules", "tab_nca", "setup", "parameter_exclusions.R"
+  ),
+  local = TRUE
+)
+
+describe(".build_exclusion_reasons", {
+  it("returns empty indices and reasons for an empty list", {
+    result <- .build_exclusion_reasons(list())
+    expect_equal(result$indices, integer(0))
+  })
+
+  it("returns correct indices and reasons for a single exclusion", {
+    lst <- list(
+      list(reason = "Outlier", rows = c(1L, 3L))
+    )
+    result <- .build_exclusion_reasons(lst)
+    expect_equal(result$indices, c(1L, 3L))
+    expect_equal(result$reasons, c("Outlier", "Outlier"))
+  })
+
+  it("concatenates reasons when multiple exclusions cover the same row", {
+    lst <- list(
+      list(reason = "Outlier", rows = c(1L, 2L)),
+      list(reason = "Protocol deviation", rows = c(2L, 4L))
+    )
+    result <- .build_exclusion_reasons(lst)
+    expect_equal(result$indices, c(1L, 2L, 4L))
+    expect_equal(result$reasons[1], "Outlier")
+    expect_equal(result$reasons[2], "Outlier; Protocol deviation")
+    expect_equal(result$reasons[3], "Protocol deviation")
+  })
+
+  it("handles non-contiguous row indices", {
+    lst <- list(
+      list(reason = "Bad sample", rows = c(5L, 10L))
+    )
+    result <- .build_exclusion_reasons(lst)
+    expect_equal(result$indices, c(5L, 10L))
+    expect_equal(result$reasons, c("Bad sample", "Bad sample"))
+  })
+})
+
+describe("rehydrate_exclusions", {
+  it("rehydrates overrides with fresh button IDs", {
+    excl_list <- shiny::reactiveVal(list())
+    counter <- shiny::reactiveVal(0L)
+
+    overrides <- list(
+      list(reason = "Outlier", rows = c(1L, 3L)),
+      list(reason = "Protocol deviation", rows = c(2L))
+    )
+
+    shiny::isolate({
+      rehydrate_exclusions(overrides, excl_list, counter,
+                           prefix = "remove_param_excl_")
+
+      result <- excl_list()
+      expect_length(result, 2)
+      expect_equal(result[[1]]$reason, "Outlier")
+      expect_equal(result[[1]]$rows, c(1L, 3L))
+      expect_equal(result[[1]]$xbtn_id, "remove_param_excl_1")
+      expect_equal(result[[2]]$reason, "Protocol deviation")
+      expect_equal(result[[2]]$rows, 2L)
+      expect_equal(result[[2]]$xbtn_id, "remove_param_excl_2")
+      expect_equal(counter(), 2L)
+    })
+  })
+
+  it("continues counter from existing value", {
+    excl_list <- shiny::reactiveVal(list())
+    counter <- shiny::reactiveVal(5L)
+
+    overrides <- list(
+      list(reason = "Reason A", rows = c(1L))
+    )
+
+    shiny::isolate({
+      rehydrate_exclusions(overrides, excl_list, counter,
+                           prefix = "remove_param_excl_")
+
+      result <- excl_list()
+      expect_equal(result[[1]]$xbtn_id, "remove_param_excl_6")
+      expect_equal(counter(), 6L)
+    })
+  })
+
+  it("works with different prefixes", {
+    excl_list <- shiny::reactiveVal(list())
+    counter <- shiny::reactiveVal(0L)
+
+    overrides <- list(
+      list(reason = "Test", rows = c(1L))
+    )
+
+    shiny::isolate({
+      rehydrate_exclusions(overrides, excl_list, counter,
+                           prefix = "remove_exclusion_reason_")
+
+      result <- excl_list()
+      expect_equal(result[[1]]$xbtn_id, "remove_exclusion_reason_1")
+    })
+  })
+})
+
+describe("clean_exclusion_list", {
+  it("strips xbtn_id and preserves reason and rows", {
+    raw_list <- list(
+      list(reason = "Outlier", rows = c(1L, 3L), xbtn_id = "remove_param_excl_1"),
+      list(reason = "PD", rows = c(2L), xbtn_id = "remove_param_excl_2")
+    )
+    clean <- clean_exclusion_list(raw_list)
+
+    expect_length(clean, 2)
+    expect_null(clean[[1]]$xbtn_id)
+    expect_null(clean[[2]]$xbtn_id)
+    expect_equal(clean[[1]]$reason, "Outlier")
+    expect_equal(clean[[1]]$rows, c(1L, 3L))
+    expect_equal(clean[[2]]$reason, "PD")
+  })
+
+  it("returns empty list for empty input", {
+    expect_equal(clean_exclusion_list(list()), list())
+  })
+})
+
+describe("exclusion list round-trip", {
+  it("clean → rehydrate → build_reasons preserves data", {
+    raw_list <- list(
+      list(reason = "Outlier", rows = c(1L, 3L), xbtn_id = "remove_param_excl_1"),
+      list(reason = "PD", rows = c(2L), xbtn_id = "remove_param_excl_2")
+    )
+    clean <- clean_exclusion_list(raw_list)
+
+    excl_list <- shiny::reactiveVal(list())
+    counter <- shiny::reactiveVal(0L)
+
+    shiny::isolate({
+      rehydrate_exclusions(clean, excl_list, counter,
+                           prefix = "remove_param_excl_")
+      result <- excl_list()
+      expect_length(result, 2)
+      expect_equal(result[[1]]$reason, "Outlier")
+      expect_equal(result[[1]]$rows, c(1L, 3L))
+      expect_true(!is.null(result[[1]]$xbtn_id))
+
+      info <- .build_exclusion_reasons(result)
+      expect_equal(info$indices, c(1L, 2L, 3L))
+      expect_equal(info$reasons[1], "Outlier")
+      expect_equal(info$reasons[2], "PD")
+      expect_equal(info$reasons[3], "Outlier")
+    })
+  })
+})


### PR DESCRIPTION
## Issue

Closes #1110

## Description

Persists parameter exclusions (PPSUM1F/PPSUM1R) in the settings YAML file so they survive download/upload round-trips.

Exclusions are stored by key (grouping columns + PPTESTCD + PPORRES) rather than row index, so they can be validated against the current NCA results on restore. If a result value has changed since the settings were saved, the exclusion is skipped and a warning banner is shown in the Parameter Exclusions panel.

### Flow

1. User uploads settings — exclusions are queued in `pending_override`
2. User clicks Run NCA — `res_nca()` fires, pending exclusions are matched against results by key
3. Matched exclusions are restored with resolved row indices
4. Unmatched exclusions produce a dismissible alert banner listing the entries that couldn't be matched

### Changes

- **`parameter_exclusions.R`**: Accept `param_excl_override` reactive. Store `keys` (data frame of identifying columns) alongside row indices. Deferred restore via `pending_override` + `res_nca()` observer. Key matching via `.match_keys_to_rows()`. Alert banner for mismatches.
- **`tab_nca.R`**: Extract `param_exclusions` from `settings_override`, pass to module, store in `session$userData`.
- **`nca_setup.R`** / **`zip-utils.R`**: Include `param_exclusions` in settings YAML.
- **`exclusion-utils.R`**: Shared utilities for both exclusion modules.
- **`test-parameter_exclusions.R`**: Tests for key extraction, matching, restore, and shared utilities.

## Definition of Done

- Settings YAML download includes PP exclusion entries with key columns
- Uploading a settings file restores exclusions only when key values match current results
- Unmatched exclusions show a warning banner in the Parameter Exclusions panel
- Shared utilities are used by `parameter_exclusions.R`; `general_exclusions.R` migration tracked in #1126

## How to test

1. Upload data and run NCA
2. Go to Parameter Exclusions, exclude some rows with a reason
3. Download settings YAML — verify it contains a `param_exclusions` section with `reason` and `keys` (not row indices)
4. Reload the app, upload the same data, upload the saved settings YAML, run NCA
5. Verify the Parameter Exclusions panel shows the previously excluded rows
6. Edit the YAML to change a `PPORRES` value, re-upload, run NCA — verify a warning banner appears listing the unmatched exclusion
7. Repeat steps 3–5 using the ZIP export instead of standalone settings download

## Contributor checklist
- [x] Code passes lintr checks
- [ ] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [x] Settings upload works with the new implementation (if applicable)

## Notes to reviewer

- The return type of `parameter_exclusions_server` changed: it now returns a clean list with `reason` + `keys` (no `rows` or `xbtn_id`). The caller (`tab_nca.R`) computes `excl_info` via `.build_exclusion_reasons()`.
- Key matching uses `as.character()` comparison to handle type differences between YAML-parsed values and data frame columns.
- The `pending_override` pattern ensures exclusions are only applied after NCA results exist, avoiding the race condition where the fingerprint observer would immediately clear them."