### PR TITLE
fix: units table hides PCSPEC groups with no selected parameters

### DIFF
--- a/inst/shiny/modules/tab_nca/units_table.R
+++ b/inst/shiny/modules/tab_nca/units_table.R
@@ -57,21 +57,29 @@ units_table_server <- function(id, mydata) {
       ))
     })
 
-    # Define rows from units table not of interest for the user
+    # Define rows from units table not of interest for the user.
+    # Group filtering (e.g., by PCSPEC) is independent of parameter flags so
+    # that specimen types like URINE remain visible even when no excretion
+    # parameters are currently selected for that specimen.
     rows_to_hide_units_table <- reactive({
       group_cols <- intersect(
         names(PKNCA::getGroups(mydata()$conc)), names(mydata()$units)
       )
-      groups_to_keep <- select(mydata()$intervals, any_of(group_cols))
       params_to_keep <- names(purrr::keep(mydata()$intervals, ~ is.logical(.x) && any(.x)))
 
       rows_to_keep <- mydata()$units %>%
         mutate(nrow = row_number()) %>%
         filter(PPTESTCD %in% params_to_keep)
-      if (ncol(groups_to_keep) > 0) {
-        rows_to_keep <- inner_join(
-          rows_to_keep, unique(groups_to_keep),
-          by = intersect(names(rows_to_keep), names(groups_to_keep))
+
+      if (length(group_cols) > 0) {
+        # Keep rows whose group values appear anywhere in the intervals,
+        # regardless of which parameters are flagged TRUE.
+        all_interval_groups <- mydata()$intervals %>%
+          select(any_of(group_cols)) %>%
+          unique()
+        rows_to_keep <- semi_join(
+          rows_to_keep, all_interval_groups,
+          by = intersect(names(rows_to_keep), names(all_interval_groups))
         )
       }
 


### PR DESCRIPTION
## Issue

Closes #1144

## Description

The Parameter Units table hid all rows for a PCSPEC group (e.g., URINE) when no NCA parameters were flagged `TRUE` in the intervals for that specimen. This happened because `rows_to_hide_units_table` used an `inner_join` that coupled group visibility to parameter flags — if no excretion parameters were selected, URINE groups had no matching rows and were hidden entirely.

The fix changes the group filtering to use a `semi_join` against all interval groups, independent of parameter flags. Specimen types now remain visible in the units table as long as they are present in the active intervals.

## Definition of Done

- Units table shows rows for all PCSPEC values present in the filtered intervals, regardless of whether any parameters are currently selected for that specimen type.

## How to test

1. Upload a dataset with both PLASMA and URINE specimens (URINE having only 1 time point per subject).
2. Go to NCA Setup → Settings.
3. Add URINE to the PCSPEC selector.
4. Click "Parameter Units" button.
5. Verify that URINE rows appear in the units table (previously they were hidden).

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] App or package changes are reflected in NEWS
- [ ] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)

## Notes to reviewer

Single-file change in `inst/shiny/modules/tab_nca/units_table.R`. The `rows_to_hide_units_table` reactive now derives visible groups from all intervals via `semi_join` instead of coupling them to parameter flags via `inner_join`. No new dependencies or behavioral changes for the PLASMA-only case — the change only affects scenarios where a specimen type has no parameters flagged TRUE in its intervals.