### PR TITLE
fix: handle missing PPORRES in 0-row pk.nca results

### DIFF
--- a/R/get_halflife_plots.R
+++ b/R/get_halflife_plots.R
@@ -191,6 +191,12 @@ get_halflife_plots <- function(pknca_data, add_annotations = TRUE,
       o_nca$result$PPSTRESU <- o_nca$result$PPORRESU
     }
   }
+  # pk.nca() with units can return 0-row results containing PPSTRES but not
+
+  # PPORRES. Ensure PPORRES exists so as.data.frame(out_format="wide") works.
+  if (!"PPORRES" %in% names(o_nca$result)) {
+    o_nca$result$PPORRES <- o_nca$result$PPSTRES
+  }
 
   wide_output <- o_nca
   wide_output$result <- wide_output$result %>%


### PR DESCRIPTION
## Issue

Closes #1192

## Description

When `pk.nca()` returns a 0-row result with units enabled, the empty tibble schema contains `PPSTRES`, `PPSTRESU`, `PPORRESU` but not `PPORRES`. The existing guard at line 188 only handled the reverse case (missing `PPSTRES` → copy from `PPORRES`). Since `PPSTRES` existed, the block was skipped, `PPORRES` was never created, and `as.data.frame(out_format = "wide")` crashed on `tidyr::spread` with `Column PPORRES doesn't exist`.

This occurs when a subject/group has all-NA concentration values (e.g. antibody analytes) and the slope selector triggers `get_halflife_plots`.

**Fix:** Add a symmetric guard — if `PPORRES` is missing, create it from `PPSTRES`.

## Definition of Done

- `get_halflife_plots` no longer crashes when `pk.nca()` returns a 0-row result with units

## How to test

1. Upload a dataset with an analyte group where all `AVAL` values are `NA` (e.g. antibody data)
2. Navigate to NCA > Slope Selector
3. The half-life plots should render without error (empty for the all-NA group)

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [ ] New logic covered by unit tests
- [x] New logic is documented
- [ ] App or package changes are reflected in NEWS
- [ ] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)
- [ ] If any `.scss` change was done, run `data-raw/compile_css.R`

## Notes to reviewer

The fix is a 3-line guard that mirrors the existing `PPSTRES` guard. The root cause was confirmed via `browser()` debugging — `pk.nca()` with units produces a 0-row tibble whose schema comes from the units conversion path, which creates `PPSTRES` columns but not `PPORRES`.