### PR TITLE
Add validation for invalid CONCDUR values in format_pkncaconc_data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9157
+Version: 0.1.0.9158
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -87,7 +87,7 @@ format_pkncaconc_data <- function(ADNCA,
       (ADNCA[["CONCDUR"]] < 0 | is.infinite(ADNCA[["CONCDUR"]]))
     if (any(invalid_concdur)) {
       n_invalid <- sum(invalid_concdur)
-      warning(
+      stop(
         n_invalid, " record(s) have invalid sampling duration (CONCDUR): ",
         "values are negative or infinite. ",
         "CONCDUR is calculated as '", time_end_column, "' - '", time_column, "'. ",

--- a/R/format_data.R
+++ b/R/format_data.R
@@ -82,6 +82,20 @@ format_pkncaconc_data <- function(ADNCA,
 
   if (!is.null(time_end_column)) {
     ADNCA[["CONCDUR"]] <- ADNCA[[time_end_column]] - ADNCA[[time_column]]
+
+    invalid_concdur <- !is.na(ADNCA[["CONCDUR"]]) &
+      (ADNCA[["CONCDUR"]] < 0 | is.infinite(ADNCA[["CONCDUR"]]))
+    if (any(invalid_concdur)) {
+      n_invalid <- sum(invalid_concdur)
+      warning(
+        n_invalid, " record(s) have invalid sampling duration (CONCDUR): ",
+        "values are negative or infinite. ",
+        "CONCDUR is calculated as '", time_end_column, "' - '", time_column, "'. ",
+        "Please check that '", time_end_column, "' and '", time_column,
+        "' are correct in your data.",
+        call. = FALSE
+      )
+    }
   }
 
   if (!is.null(nca_exclude_reason_columns)) {

--- a/tests/testthat/test-format_data.R
+++ b/tests/testthat/test-format_data.R
@@ -180,7 +180,7 @@ describe("format_pkncaconc_data", {
 
   it("does not error when CONCDUR values are valid", {
     adnca <- ADNCA %>%
-      mutate(AEFRLT = AFRLT + 0.5)  # valid: AEFRLT > AFRLT
+      mutate(AEFRLT = AFRLT + 0.5)
 
     expect_no_error(
       format_pkncaconc_data(adnca,

--- a/tests/testthat/test-format_data.R
+++ b/tests/testthat/test-format_data.R
@@ -146,11 +146,11 @@ describe("format_pkncaconc_data", {
     )
   })
 
-  it("warns when CONCDUR has negative values", {
+  it("errors when CONCDUR has negative values", {
     adnca <- ADNCA %>%
       mutate(AEFRLT = AFRLT - 1)  # AEFRLT < AFRLT => negative CONCDUR
 
-    expect_warning(
+    expect_error(
       format_pkncaconc_data(adnca,
                             group_columns = c("STUDYID", "USUBJID", "PCSPEC",
                                               "DOSETRT", "PARAM"),
@@ -162,11 +162,11 @@ describe("format_pkncaconc_data", {
     )
   })
 
-  it("warns when CONCDUR has infinite values", {
+  it("errors when CONCDUR has infinite values", {
     adnca <- ADNCA %>%
       mutate(AEFRLT = ifelse(row_number() == 1, Inf, AFRLT))
 
-    expect_warning(
+    expect_error(
       format_pkncaconc_data(adnca,
                             group_columns = c("STUDYID", "USUBJID", "PCSPEC",
                                               "DOSETRT", "PARAM"),
@@ -178,15 +178,26 @@ describe("format_pkncaconc_data", {
     )
   })
 
-  it("does not warn when CONCDUR values are valid", {
+  it("does not error when CONCDUR values are valid", {
     adnca <- ADNCA %>%
       mutate(AEFRLT = AFRLT + 0.5)  # valid: AEFRLT > AFRLT
 
-    expect_no_warning(
+    expect_no_error(
       format_pkncaconc_data(adnca,
                             group_columns = c("STUDYID", "USUBJID", "PCSPEC",
                                               "DOSETRT", "PARAM"),
                             time_end_column = "AEFRLT",
+                            time_column = "AFRLT",
+                            rrlt_column = "ARRLT",
+                            dose_group_columns = c("STUDYID", "USUBJID", "DOSETRT"))
+    )
+  })
+
+  it("does not error when no time_end_column is provided (no CONCDUR created)", {
+    expect_no_error(
+      format_pkncaconc_data(ADNCA,
+                            group_columns = c("STUDYID", "USUBJID", "PCSPEC",
+                                              "DOSETRT", "PARAM"),
                             time_column = "AFRLT",
                             rrlt_column = "ARRLT",
                             dose_group_columns = c("STUDYID", "USUBJID", "DOSETRT"))

--- a/tests/testthat/test-format_data.R
+++ b/tests/testthat/test-format_data.R
@@ -146,6 +146,53 @@ describe("format_pkncaconc_data", {
     )
   })
 
+  it("warns when CONCDUR has negative values", {
+    adnca <- ADNCA %>%
+      mutate(AEFRLT = AFRLT - 1)  # AEFRLT < AFRLT => negative CONCDUR
+
+    expect_warning(
+      format_pkncaconc_data(adnca,
+                            group_columns = c("STUDYID", "USUBJID", "PCSPEC",
+                                              "DOSETRT", "PARAM"),
+                            time_end_column = "AEFRLT",
+                            time_column = "AFRLT",
+                            rrlt_column = "ARRLT",
+                            dose_group_columns = c("STUDYID", "USUBJID", "DOSETRT")),
+      regexp = "record\\(s\\) have invalid sampling duration \\(CONCDUR\\)"
+    )
+  })
+
+  it("warns when CONCDUR has infinite values", {
+    adnca <- ADNCA %>%
+      mutate(AEFRLT = ifelse(row_number() == 1, Inf, AFRLT))
+
+    expect_warning(
+      format_pkncaconc_data(adnca,
+                            group_columns = c("STUDYID", "USUBJID", "PCSPEC",
+                                              "DOSETRT", "PARAM"),
+                            time_end_column = "AEFRLT",
+                            time_column = "AFRLT",
+                            rrlt_column = "ARRLT",
+                            dose_group_columns = c("STUDYID", "USUBJID", "DOSETRT")),
+      regexp = "record\\(s\\) have invalid sampling duration \\(CONCDUR\\)"
+    )
+  })
+
+  it("does not warn when CONCDUR values are valid", {
+    adnca <- ADNCA %>%
+      mutate(AEFRLT = AFRLT + 0.5)  # valid: AEFRLT > AFRLT
+
+    expect_no_warning(
+      format_pkncaconc_data(adnca,
+                            group_columns = c("STUDYID", "USUBJID", "PCSPEC",
+                                              "DOSETRT", "PARAM"),
+                            time_end_column = "AEFRLT",
+                            time_column = "AFRLT",
+                            rrlt_column = "ARRLT",
+                            dose_group_columns = c("STUDYID", "USUBJID", "DOSETRT"))
+    )
+  })
+
   test_that("using nca_exclude_reason_columns concatenates exclusion reasons correctly", {
     test_df <- ADNCA
     nrows <- nrow(ADNCA)


### PR DESCRIPTION
## Issue

Closes #1152

## Description

When `CONCDUR` (calculated as `time_end_column - time_column`, typically `AEFRLT - AFRLT`) contains negative or infinite values, PKNCA throws a vague error:

> duration must be numeric without missing (NA) or infinite values, and all values must be >= 0

Since `CONCDUR` is created internally, users have no way to understand this message. This PR adds a validation check in `format_pkncaconc_data` that stops with a clear error message telling the user how many records are invalid, how `CONCDUR` is derived, and which columns to check in their data.

The check runs before PKNCA receives the data, so the vague error never appears.

## Definition of Done

- [x] Validation check within `format_pkncaconc_data` that checks if CONCDUR is < 0 or Inf
- [x] Error given to user if yes, detailing that they should check that AFRLT and AEFRLT are correct

## How to test

1. Upload data where `AEFRLT < AFRLT` for some records — should see a clear error in the UI naming the affected columns
2. Upload data without `AEFRLT` — should work normally (no CONCDUR validation triggered)
3. Upload valid data with `AEFRLT >= AFRLT` — should work normally

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [x] R script works with the new implementation (if applicable)
- [x] Settings upload works with the new implementation (if applicable)
- [x] If any `.scss` change was done, run `data-raw/compile_css.R`
- [x] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`

## Notes to reviewer

The validation uses `stop()` rather than `warning()` because warnings are not surfaced in the Shiny UI (only errors are caught by `tryCatch` and shown as notifications). This also prevents the vague PKNCA error from ever appearing.
