### PR TITLE
Fix settings upload crash with empty int_parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9162
+Version: 0.1.0.9163
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-<<<<<<< 1272-bug/int-parameters-settings-upload
-Version: 0.1.0.9163
-=======
-Version: 0.1.0.9164
->>>>>>> main
+Version: 0.1.0.9165
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -63,7 +63,6 @@
 
 
 ## Bugs fixed
-* Fixed settings upload crash when no partial interval parameters are defined. Empty `int_parameters` tibble serialized to YAML `[]` arrays which parsed back as NULL (#1272)
 * Last dose interval end time now extends to the last observed sample instead of being cut off at TRTRINT (tau), ensuring all collected data points are included in NCA calculations (#1235)
 * Fixed NA `PPSTRESU` handling across NCA results: descriptive statistics no longer crash when a parameter group has all-NA units, and manual interval parameters (e.g., RCAMINT) no longer get `NA` appended to their column names (#1216)
 * `get_settings_code()` now reads mapping, filters, ratio table, and units from the settings YAML instead of using hardcoded defaults. Legacy YAML files without these fields still work via fallback. The `mapping` parameter has been removed (#1189)

--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,7 @@
 
 
 ## Bugs fixed
+* Fixed settings upload crash when no partial interval parameters are defined. Empty `int_parameters` tibble serialized to YAML `[]` arrays which parsed back as NULL (#1272)
 * Last dose interval end time now extends to the last observed sample instead of being cut off at TRTRINT (tau), ensuring all collected data points are included in NCA calculations (#1235)
 * Fixed NA `PPSTRESU` handling across NCA results: descriptive statistics no longer crash when a parameter group has all-NA units, and manual interval parameters (e.g., RCAMINT) no longer get `NA` appended to their column names (#1216)
 * `get_settings_code()` now reads mapping, filters, ratio table, and units from the settings YAML instead of using hardcoded defaults. Legacy YAML files without these fields still work via fallback. The `mapping` parameter has been removed (#1189)

--- a/inst/shiny/modules/tab_nca/setup/settings.R
+++ b/inst/shiny/modules/tab_nca/setup/settings.R
@@ -480,7 +480,7 @@ settings_server <- function(id, data, adnca_data, settings_override) {
           blq_strategy = data_imputation$blq_strategy(),
           blq_imputation_rule = data_imputation$blq_imputation_rule()
         ),
-        int_parameters = int_parameters(),
+        int_parameters = if (nrow(int_parameters()) > 0) int_parameters() else NULL,
         flags = list(
           R2ADJ = list(
             is.checked = input$R2ADJ_rule,


### PR DESCRIPTION
## Issue

Closes #1272

## Description

After #1252 changed the default `int_parameters` to an empty tibble, saving settings serializes the empty columns as YAML `[]` arrays. On restore, YAML parses `[]` as `NULL`, producing a list of NULLs instead of a tibble. The `!is.null` check passes but `.build_interval_param_options()` crashes accessing `int_params$start_auc`.

Fix: write `NULL` instead of the empty tibble to settings YAML, so `int_parameters` is omitted (`~` in YAML). On restore, the existing `if (!is.null(...))` guard skips it and the default empty tibble remains. Follows the same pattern as #1262.

## Definition of Done

- Settings upload no longer crashes when no partial interval parameters are defined

## How to test

1. Open the app, do not add any partial interval parameters
2. Download settings
3. Upload the same settings file
4. Verify no crash occurs

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [x] R script works with the new implementation (if applicable)
- [x] Settings upload works with the new implementation (if applicable)
- [x] If any `.scss` change was done, run `data-raw/compile_css.R`
- [x] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`

## Notes to reviewer

One-line change. The bug was introduced by #1252 (empty tibble default) and doesn't exist in the last CRAN release, so no NEWS entry.