### PR TITLE
fix: scale exploration plot height dynamically with facet count

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9163
+Version: 0.1.0.9164
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,7 @@
 
 
 ## Bugs fixed
+* Exploration plots no longer shrink middle-row subplots when faceting by many levels (e.g. USUBJID). Plot height now scales dynamically with the number of facet panels (#1283)
 * Last dose interval end time now extends to the last observed sample instead of being cut off at TRTRINT (tau), ensuring all collected data points are included in NCA calculations (#1235)
 * Fixed NA `PPSTRESU` handling across NCA results: descriptive statistics no longer crash when a parameter group has all-NA units, and manual interval parameters (e.g., RCAMINT) no longer get `NA` appended to their column names (#1216)
 * `get_settings_code()` now reads mapping, filters, ratio table, and units from the settings YAML instead of using hardcoded defaults. Legacy YAML files without these fields still work via fallback. The `mapping` parameter has been removed (#1189)

--- a/inst/shiny/modules/tab_explore.R
+++ b/inst/shiny/modules/tab_explore.R
@@ -1,6 +1,28 @@
 # The Exploration Navbar tab loads the data from the Data tab, and results from NCA tab
 # The user can then explore the data using various visualisation tools
 
+#' Compute plotly height that scales with the number of facet panels.
+#' Returns NULL (plotly default) when there are few panels, so small
+#' plots are unaffected.
+#' @param p A ggplot object, possibly with facet_wrap.
+#' @param row_height Pixel height per row of facet panels.
+#' @param min_height Minimum height in pixels.
+#' @noRd
+.facet_plot_height <- function(p, row_height = 300, min_height = 500) {
+  facet <- p$facet
+  if (!inherits(facet, "FacetWrap")) {
+    return(NULL)
+  }
+  facet_vars <- names(facet$params$facets)
+  n_facets <- nrow(unique(p$data[facet_vars]))
+  if (is.null(n_facets) || n_facets <= 4) {
+    return(NULL)
+  }
+  ncol <- facet$params$ncol %||% ceiling(sqrt(n_facets))
+  nrow <- ceiling(n_facets / ncol)
+  max(min_height, nrow * row_height)
+}
+
 # EXPLORATION ----
 tab_explore_ui <- function(id) {
   ns <- NS(id)
@@ -17,8 +39,8 @@ tab_explore_ui <- function(id) {
           is_mean_plot = FALSE,
           extra_ui = saved_outputs_ui(ns("saved_outputs_indiv"))
         ),
-        fillable = TRUE,
-        plotlyOutput(ns("individualplot"), height = "100%"),
+        fillable = FALSE,
+        plotlyOutput(ns("individualplot")),
         br(), br()
       )
     ),
@@ -30,8 +52,8 @@ tab_explore_ui <- function(id) {
           is_mean_plot = TRUE,
           extra_ui = saved_outputs_ui(ns("saved_outputs_mean"))
         ),
-        fillable = TRUE,
-        plotlyOutput(ns("mean_plot"), height = "100%"),
+        fillable = FALSE,
+        plotlyOutput(ns("mean_plot")),
         br(), br()
       )
     ),
@@ -108,7 +130,8 @@ tab_explore_server <- function(id, pknca_data, extra_group_vars) {
     # Render the individual plot in plotly
     output$individualplot <- renderPlotly({
       req(individualplot())
-      ggplotly(individualplot(), tooltip = "tooltip_text")
+      height <- .facet_plot_height(individualplot())
+      ggplotly(individualplot(), tooltip = "tooltip_text", height = height)
     })
 
     meanplot <- reactive({
@@ -161,7 +184,8 @@ tab_explore_server <- function(id, pknca_data, extra_group_vars) {
     # Render the mean plot output in plotly
     output$mean_plot <- renderPlotly({
       req(meanplot())
-      ggplotly(meanplot(), tooltip = "tooltip_text")
+      height <- .facet_plot_height(meanplot())
+      ggplotly(meanplot(), tooltip = "tooltip_text", height = height)
     })
 
     qc_plot_outputs <- pk_dose_qc_plot_server(


### PR DESCRIPTION
## Issue

Closes #1283

## Description

When faceting exploration plots by a variable with many levels (e.g. USUBJID), the subplots in the middle rows shrink and become unreadable. This happened because the plot container used a fixed viewport height (`height = \"90vh\"`, `fillable = TRUE`) and `plotlyOutput(height = \"100%\")` — plotly tried to fit all panels within that fixed space.

**Changes:**
- Added `.facet_plot_height()` helper that computes a dynamic pixel height based on the number of facet panels (300px per row, minimum 500px). Returns `NULL` for plots with ≤4 panels so small plots are unaffected.
- Applied the helper to both individual and mean plot `renderPlotly` calls.
- Switched `layout_sidebar` containers from `fillable = TRUE` to `fillable = FALSE` and removed `height = \"100%\"` from `plotlyOutput`, so large faceted plots extend beyond the viewport and scroll naturally.

## Definition of Done

- [x] Exploration plots (individual and mean) scale their height dynamically based on the number of facet panels
- [x] Middle-row subplots render at the same size as top/bottom rows
- [x] Large faceted plots are scrollable within the exploration tab
- [x] Existing plots with few facets (≤4) are not affected

## How to test

1. Upload a dataset with many subjects (20+)
2. Go to Exploration > Individual Plots
3. Set Facet By to USUBJID
4. Verify all subplots render at equal size and the plot is scrollable
5. Switch to a facet variable with few levels (e.g. PCSPEC) — verify the plot looks the same as before

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)
- [ ] If any `.scss` change was done, run `data-raw/compile_css.R`

## Notes to reviewer

- The `.facet_plot_height()` helper uses `p$facet` and `p$data` to count panels without re-querying the data. It only activates for `FacetWrap` with >4 panels.
- The QC plot module (`qc_plot.R`) already uses a similar dynamic height pattern but computes it differently (based on subjects × groups). This helper is simpler since it only needs the facet panel count.
- Switching `fillable = FALSE` changes the layout behavior — the plot area now scrolls independently. Worth testing that sidebar interactions (zoom, hover) still work correctly with the scrollable container.