### PR TITLE
Renaming "Aggregate Subject" Label to "Mean Across Subjects"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 * Settings upload is flexible — non-data-specific template settings can be uploaded (#993)
 
 ### NCA Setup
+* Renamed "Aggregate Subject" label to "Mean across subjects" in ratio calculations for clarity; updated help text to explain matching mechanics (#1297)
 * Parameter Selection tab now contains Partial Intervals, Ratio Calculations, and Units alongside the parameter matrix. The former Settings tab is renamed to General Settings (#1239)
 * Parameter selection UI replaced with an interactive checkbox matrix (study types × parameters) with Select All, Defaults, and Clear All buttons (#795)
 * Partial interval parameters section supports calculations beyond `AUCINT`: `RCAMINT`, `AUCINTD`, `CAVGINT`, and others. Table starts empty by default with a Remove Row button (#524, #1249)

--- a/inst/shiny/modules/tab_nca/setup/ratio_calculations_table.R
+++ b/inst/shiny/modules/tab_nca/setup/ratio_calculations_table.R
@@ -45,10 +45,11 @@ ratios_table_ui <- function(id) {
         ),
         tags$li(
           tags$b("Mean across subjects"),
-          ": Controls whether reference values are averaged across subjects.
-          `no` (\u2014) matches within the same subject, `yes` (x\u0304) uses the
-          mean reference across all subjects, `if-needed` (x\u0304?) tries
-          individual matching first and falls back to mean."
+          ": Controls how test and reference rows are paired. Ratios match
+          on grouping variables (e.g., USUBJID, PCSPEC, profile).
+          `no` (\u2014) includes USUBJID in matching (same subject's reference),
+          `yes` (x\u0304) removes USUBJID (mean reference across all subjects),
+          `if-needed` (x\u0304?) tries per-subject first, falls back to mean."
         ),
         tags$li(
           tags$b("RefParameter"),

--- a/inst/shiny/modules/tab_nca/setup/ratio_calculations_table.R
+++ b/inst/shiny/modules/tab_nca/setup/ratio_calculations_table.R
@@ -44,10 +44,11 @@ ratios_table_ui <- function(id) {
           other values of the variable (e.g., Groups = B, C, D)"
         ),
         tags$li(
-          tags$b("Aggregate Subject"),
-          ": Shown in the denominator. `yes` (x\u0304) aggregates reference
-          values using the mean of all subjects, `no` (\u2014) does not, and
-          `if-needed` (x\u0304?) only when ratios cannot be performed within the same subject."
+          tags$b("Mean across subjects"),
+          ": Controls whether reference values are averaged across subjects.
+          `no` (\u2014) matches within the same subject, `yes` (x\u0304) uses the
+          mean reference across all subjects, `if-needed` (x\u0304?) tries
+          individual matching first and falls back to mean."
         ),
         tags$li(
           tags$b("RefParameter"),
@@ -388,7 +389,7 @@ ratios_table_server <- function(
         class = "ratio-denominator",
         tags$div(
           class = "ratio-sigma",
-          title = "Aggregate Subject: \u2014 = no, x\u0304 = yes (mean), x\u0304? = if-needed",
+          title = "Mean across subjects: \u2014 = no, x\u0304 = yes, x\u0304? = if-needed",
           selectInput(
             ns(paste0("AggregateSubject_", i)), label = NULL,
             choices = agg_choices, selected = row$AggregateSubject,

--- a/vignettes/ratio-calculations.Rmd
+++ b/vignettes/ratio-calculations.Rmd
@@ -30,7 +30,7 @@ Each ratio is defined by:
 | **Ref Parameter** | PK parameter for the denominator (defaults to same as test) |
 | **Test Groups** | Group level for the numerator. `(all other levels)` uses every level except the reference. |
 | **Ref Groups** | Group level for the denominator (e.g. `PARAM: ParentDrug`) |
-| **Aggregate** | `no` = within-subject ratio; `yes` = mean of reference across subjects; `if-needed` = falls back to aggregation when within-subject matching is not possible |
+| **Mean across subjects** | `no` = within-subject ratio; `yes` = mean of reference across subjects; `if-needed` = falls back to aggregation when within-subject matching is not possible |
 | **Adj. Factor** | Multiplier applied to the ratio (e.g. molecular weight correction) |
 | **PPTESTCD** | Auto-generated CDISC code; editable |
 
@@ -204,7 +204,7 @@ $$F_{rel} = \frac{AUC_{\text{test formulation}}}{AUC_{\text{ref formulation}}} \
 
 - The distinction between `FABS` and `FREL` is automatic: if the reference
   route is intravascular, aNCA assigns `FABS`; otherwise `FREL`.
-- For crossover studies, use `Aggregate: no` to compute within-subject ratios.
+- For crossover studies, use `Mean across subjects: no` to compute within-subject ratios.
 
 ---
 
@@ -241,10 +241,10 @@ $$RA_{CMAX} = \frac{CMAX_{\text{test group}}}{CMAX_{\text{ref group}}} \times \t
 
 ---
 
-# Aggregation Modes
+# Mean Across Subjects
 
-The **Aggregate** setting controls how reference values are handled when
-subjects differ between test and reference groups:
+The **Mean across subjects** setting controls how reference values are handled
+when subjects differ between test and reference groups:
 
 | Mode | Behavior |
 |---|---|


### PR DESCRIPTION
## Issue

Closes #1297

## Description

Renamed the "Aggregate Subject" label to "Mean across subjects" in the ratio calculations UI.

Updated the help dropdown text to explain matching mechanics (how test and reference rows are joined by grouping variables, and how the setting controls USUBJID inclusion). 

Updated the tooltip and vignette documentation to match.

Change is a display-only change as the internal AggregateSubject YAML key and column name remain unchanged for backward compatibility.


## Definition of Done

- [x] Label and tooltip updated in `ratio_calculations_table.R`
- [x] Column header in the ratio table updated
- [x] Help dropdown text updated with matching explanation
- [x] Settings YAML key remains `AggregateSubject` for backward compatibility (display-only change)
- [x] NEWS entry added

## How to test

1. load with `devtools::load_all(); run_app()`
2. upload data &  navigate to NCA tab > Parameter Selection > Ratio Calculations
3. Add a ratio row
4. Hover over the `—`/`x̄`/`x̄?` dropdown → tooltip should say "Mean across subjects: — = no, x̄ = yes, x̄? = if-needed"
<img width="1324" height="268" alt="image" src="https://github.com/user-attachments/assets/8da81a0c-911c-4eba-b6df-d44c59b0b012" />
5. Click the **?** help icon → should show "Mean across subjects" with matching explanation
<img width="441" height="527" alt="image" src="https://github.com/user-attachments/assets/cf124c49-e7c2-43aa-b558-3f3fdd417fa1" />

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [ ] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)
- [ ] If any `.scss` change was done, run `data-raw/compile_css.R`
- [ ] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`

## Notes to reviewer

No logic changes to the code, just purely UI label, tooltip, help text, and vignette documentation. The internal column name `AggregateSubject` in data frames, YAML settings, and R functions are untouched for backward compatibility.