### PR TITLE
docs: fix comment typos

### DIFF
--- a/R/PKNCA.R
+++ b/R/PKNCA.R
@@ -454,7 +454,7 @@ PKNCA_calculate_nca <- function(pknca_data, blq_rule = NULL) { # nolint: object_
         # TODO (Gerardo): This is a temporary fix to prevent issues when datasets
         # drop values, this was only affecting BLQ branch (#139) but not main, related
         # with pk.nca.interval() for how we deal with it in aNCA. If BLQ imputation is
-        # done, this values dissappear and then it is considered that those times were
+        # done, this values disappear and then it is considered that those times were
         # also NA, which causes the error. In PKNCA dropping in imputation works fine,
         # but aNCA might be doing something special we are missing
         d_na <- data.frame(

--- a/R/g_pkcg.R
+++ b/R/g_pkcg.R
@@ -163,7 +163,7 @@ pkcg01 <- function(
       aes(color = !!sym(color_var)) +
       theme(legend.position = "none")
 
-    # Add color legend only when neccessary
+    # Add color legend only when necessary
     if (length(unique(adnca[[color_var]])) > 1) {
 
       # Make sure the variable is interpreted as a factor


### PR DESCRIPTION
## Issue

Closes #1362

## Description

Fixed the two spelling typos called out in code comments:

- `dissappear` -> `disappear` in `R/PKNCA.R`
- `neccessary` -> `necessary` in `R/g_pkcg.R`

## Definition of Done

- [x] `R/PKNCA.R:457` typo fixed
- [x] `R/g_pkcg.R:166` typo fixed
- [ ] `lintr` passes

## How to test

- `git diff --check`
- `grep -RIn "dissappear\\|neccessary" R/PKNCA.R R/g_pkcg.R; test $? -eq 1`
- `grep -n "disappear\\|necessary" R/PKNCA.R R/g_pkcg.R`

## Contributor checklist

- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [x] New logic is documented
- [ ] App or package changes are reflected in NEWS
- [ ] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)
- [ ] If any `.scss` change was done, run `data-raw/compile_css.R`
- [ ] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`

## Notes to reviewer

This is a code-comment-only typo fix. I could not run `lintr` or the R test suite locally because `R`/`Rscript` is not installed in this environment.
