### PR TITLE
TLG Fix Custom Titles on Combined Plots plots and broken !COLUMN syntax

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9182
+Version: 0.1.0.9183
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -133,6 +133,8 @@
 
 ### TLG
 * Fixed one-sided whiskers (Upper/Lower) collapsing to zero height in mean plots (`pkcg03`) (#1316)
+* Custom titles now apply immediately to combined graphs (`pkcg02`); graphs are rendered through dedicated `plotly` outputs so option edits redraw the plot in place instead of only after switching figures (#1336)
+* Restored the `!COLUMN` label-reference syntax in graph/listing title, subtitle, footnote, and axis inputs — column label attributes are re-applied before rendering, since the PKNCA processing pipeline strips them (#1336)
 
 ## Dependency changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -133,8 +133,7 @@
 
 ### TLG
 * Fixed one-sided whiskers (Upper/Lower) collapsing to zero height in mean plots (`pkcg03`) (#1316)
-* Custom titles now apply immediately to combined graphs (`pkcg02`); graphs are rendered through dedicated `plotly` outputs so option edits redraw the plot in place instead of only after switching figures (#1336)
-* Restored the `!COLUMN` label-reference syntax in graph/listing title, subtitle, footnote, and axis inputs — column label attributes are re-applied before rendering, since the PKNCA processing pipeline strips them (#1336)
+* Fixed TLG graph title/label handling: custom titles now apply immediately to combined graphs (`pkcg02`) via dedicated `plotly` outputs, and the `!COLUMN` label-reference syntax works again across title, subtitle, footnote, and axis inputs (column labels are re-applied before rendering, since the PKNCA pipeline strips them) (#1336)
 
 ## Dependency changes
 

--- a/inst/shiny/modules/tab_tlg/tlg_module.R
+++ b/inst/shiny/modules/tab_tlg/tlg_module.R
@@ -62,9 +62,8 @@ render_graph_outputs <- function(output, session, current_page_items) {
           req(my_i <= length(items))
           item <- items[[my_i]]
           req(!is.character(item))
-          # g_pkcg() returns plotly widgets by default (plotly = TRUE); the
-          # ggplot branch is the fallback for plotly = FALSE callers.
-          if (inherits(item, c("gg", "ggplot"))) plotly::ggplotly(item) else item
+          # implemented graph functions (g_pkcg*) always return plotly widgets
+          item
         })
       })
       n_registered <<- n

--- a/inst/shiny/modules/tab_tlg/tlg_module.R
+++ b/inst/shiny/modules/tab_tlg/tlg_module.R
@@ -21,6 +21,57 @@ filter_tlg_excluded <- function(data) {
   }
 }
 
+#' Wire up per-plot plotly outputs for a graph TLG module.
+#'
+#' Renders each graph through its own `plotlyOutput`/`renderPlotly` pair rather
+#' than returning raw plotly widgets from a single `renderUI`. Raw widgets did
+#' not redraw in place when an option changed (e.g. a custom title on combined
+#' pkcg02 plots) until the figure was hidden and shown again (issue #1336);
+#' letting plotly own each output binding makes edits apply immediately.
+#'
+#' @param output             Module `output` object.
+#' @param session            Module `session` object.
+#' @param current_page_items Reactive returning the items shown on the current
+#'                           page (plotly widgets, ggplots, or character errors).
+#' @noRd
+render_graph_outputs <- function(output, session, current_page_items) {
+  output$tlg_output <- renderUI({
+    items <- current_page_items()
+    tagList(purrr::imap(items, function(item, i) {
+      if (is.character(item)) {
+        tags$pre(item)
+      } else {
+        # preserve the height baked into the plotly object (set via ggplotly)
+        height <- if (!is.null(item$height)) paste0(item$height, "px") else "500px"
+        plotly::plotlyOutput(session$ns(paste0("plot_", i)), height = height)
+      }
+    }))
+  })
+
+  # Register a renderPlotly binding for each plot slot exactly once (tracked by
+  # high-water mark). The bodies read current_page_items() reactively, so option
+  # edits re-run them and plotly redraws the existing widget in place.
+  n_registered <- 0L
+  observe({
+    n <- length(current_page_items())
+    if (n > n_registered) {
+      for (i in seq.int(n_registered + 1L, n)) local({
+        my_i <- i
+        output[[paste0("plot_", my_i)]] <- plotly::renderPlotly({
+          items <- current_page_items()
+          req(my_i <= length(items))
+          item <- items[[my_i]]
+          req(!is.character(item))
+          # g_pkcg() returns plotly widgets by default (plotly = TRUE); the
+          # ggplot branch is the fallback for plotly = FALSE callers.
+          if (inherits(item, c("gg", "ggplot"))) plotly::ggplotly(item) else item
+        })
+      })
+      n_registered <<- n
+    }
+  })
+}
+
 #' Function generating UI for a TLG module.
 #'
 #' @param id      id of the module, preferably with randomly generated part to avoid conflicts
@@ -77,7 +128,8 @@ tlg_module_ui <- function(id, type, options) {
           selectInput(
             ns("entries_per_page"),
             "",
-            choices = c("All", 1, 2, 4, 6, 8, 10)
+            choices = c("All", 1, 2, 4, 6, 8, 10),
+            selected = 1
           )
         ),
         shinyjs::disabled(actionButton(ns("previous_page"), "Previous Page", class = "btn-page"))
@@ -116,7 +168,7 @@ tlg_module_ui <- function(id, type, options) {
 #' @param render_list function that renders the list of entries, actual implementation of the TLG
 #' @param options     list of options to customize input parameters
 #'
-tlg_module_server <- function(id, data, type, render_list, options = NULL) { # nolint: cyclocomp_linter
+tlg_module_server <- function(id, data, type, render_list, options = NULL) {
   moduleServer(id, function(input, output, session) {
     current_page <- reactiveVal(1)
 
@@ -202,45 +254,7 @@ tlg_module_server <- function(id, data, type, render_list, options = NULL) { # n
     })
 
     if (type == "graph") {
-      # Render each graph through its own plotlyOutput/renderPlotly pair rather
-      # than returning raw plotly widgets from renderUI. Returning raw widgets
-      # meant the plot did not redraw in place when an option changed (e.g. a
-      # custom title on combined pkcg02 plots) until the figure was hidden and
-      # shown again (issue #1336). Letting plotly own the output binding makes
-      # edits apply immediately.
-      output$tlg_output <- renderUI({
-        items <- current_page_items()
-        tagList(purrr::imap(items, function(item, i) {
-          if (is.character(item)) {
-            tags$pre(item)
-          } else {
-            # preserve the height baked into the plotly object (set via ggplotly)
-            height <- if (!is.null(item$height)) paste0(item$height, "px") else "500px"
-            plotly::plotlyOutput(session$ns(paste0("plot_", i)), height = height)
-          }
-        }))
-      })
-
-      # Register a renderPlotly binding for each plot slot exactly once (tracked
-      # by high-water mark). The bodies read current_page_items() reactively, so
-      # option edits re-run them and plotly redraws the existing widget in place.
-      n_registered <- 0L
-      observe({
-        n <- length(current_page_items())
-        if (n > n_registered) {
-          for (i in seq.int(n_registered + 1L, n)) local({
-            my_i <- i
-            output[[paste0("plot_", my_i)]] <- plotly::renderPlotly({
-              items <- current_page_items()
-              req(my_i <= length(items))
-              item <- items[[my_i]]
-              req(!is.character(item))
-              if (inherits(item, c("gg", "ggplot"))) plotly::ggplotly(item) else item
-            })
-          })
-          n_registered <<- n
-        }
-      })
+      render_graph_outputs(output, session, current_page_items)
     } else {
       output$tlg_output <- renderPrint(current_page_items())
     }

--- a/inst/shiny/modules/tab_tlg/tlg_module.R
+++ b/inst/shiny/modules/tab_tlg/tlg_module.R
@@ -116,14 +116,8 @@ tlg_module_ui <- function(id, type, options) {
 #' @param render_list function that renders the list of entries, actual implementation of the TLG
 #' @param options     list of options to customize input parameters
 #'
-tlg_module_server <- function(id, data, type, render_list, options = NULL) {
+tlg_module_server <- function(id, data, type, render_list, options = NULL) { # nolint: cyclocomp_linter
   moduleServer(id, function(input, output, session) {
-    render_fn <- switch(
-      type,
-      "graph" = renderUI,
-      "listing" = renderPrint
-    )
-
     current_page <- reactiveVal(1)
 
     #' updating current page based on user input
@@ -180,6 +174,10 @@ tlg_module_server <- function(id, data, type, render_list, options = NULL) {
 
       tryCatch({
         tlg_data <- filter_tlg_excluded(data()$conc$data)
+        # Restore column label attributes: the PKNCA/dplyr processing pipeline
+        # strips them, which breaks the `!COLUMN` label-reference syntax in plot
+        # title/subtitle/footnote/axis inputs (resolved via parse_annotation).
+        tlg_data <- apply_labels(tlg_data, type = "ADNCA")
         do.call(render_list, purrr::list_modify(list(data = tlg_data), !!!list_options))
       },
       error = function(e) {
@@ -191,7 +189,8 @@ tlg_module_server <- function(id, data, type, render_list, options = NULL) {
     }) %>%
       debounce(750)
 
-    output$tlg_output <- render_fn({
+    #' entries shown on the current page (slice of the full TLG list)
+    current_page_items <- reactive({
       req(tlg_list(), entries_per_page(), current_page())
 
       num_plots <- length(tlg_list())
@@ -201,6 +200,50 @@ tlg_module_server <- function(id, data, type, render_list, options = NULL) {
 
       unname(tlg_list()[page_start:page_end])
     })
+
+    if (type == "graph") {
+      # Render each graph through its own plotlyOutput/renderPlotly pair rather
+      # than returning raw plotly widgets from renderUI. Returning raw widgets
+      # meant the plot did not redraw in place when an option changed (e.g. a
+      # custom title on combined pkcg02 plots) until the figure was hidden and
+      # shown again (issue #1336). Letting plotly own the output binding makes
+      # edits apply immediately.
+      output$tlg_output <- renderUI({
+        items <- current_page_items()
+        tagList(purrr::imap(items, function(item, i) {
+          if (is.character(item)) {
+            tags$pre(item)
+          } else {
+            # preserve the height baked into the plotly object (set via ggplotly)
+            height <- if (!is.null(item$height)) paste0(item$height, "px") else "500px"
+            plotly::plotlyOutput(session$ns(paste0("plot_", i)), height = height)
+          }
+        }))
+      })
+
+      # Register a renderPlotly binding for each plot slot exactly once (tracked
+      # by high-water mark). The bodies read current_page_items() reactively, so
+      # option edits re-run them and plotly redraws the existing widget in place.
+      n_registered <- 0L
+      observe({
+        n <- length(current_page_items())
+        if (n > n_registered) {
+          for (i in seq.int(n_registered + 1L, n)) local({
+            my_i <- i
+            output[[paste0("plot_", my_i)]] <- plotly::renderPlotly({
+              items <- current_page_items()
+              req(my_i <= length(items))
+              item <- items[[my_i]]
+              req(!is.character(item))
+              if (inherits(item, c("gg", "ggplot"))) plotly::ggplotly(item) else item
+            })
+          })
+          n_registered <<- n
+        }
+      })
+    } else {
+      output$tlg_output <- renderPrint(current_page_items())
+    }
 
     options_values <- lapply(names(options), function(option) {
       if (is.character(options[[option]])) return(NULL)

--- a/tests/testthat/test-tlg_module.R
+++ b/tests/testthat/test-tlg_module.R
@@ -187,4 +187,63 @@ describe("tlg_module_server", {
   # which requires a running Shiny session; the debounce(750) reactive also
   # caches and re-throws the error before the tryCatch return value can be
   # observed.  This path is covered by end-to-end / integration tests.
+
+  it("restores column labels before rendering (issue #1336, `!COL` syntax)", {
+    # The PKNCA/dplyr pipeline strips label attributes from conc$data, which
+    # broke the `!COLUMN` label-reference syntax. tlg_list() must re-apply
+    # labels so parse_annotation() can resolve them in plot annotations.
+    captured <- NULL
+    capture_fn <- function(data, ...) {
+      captured <<- data
+      list("plot_a")
+    }
+    unlabeled_df <- data.frame(
+      NFRLT = 1:3, AVAL = c(5, 4, 3), stringsAsFactors = FALSE
+    )
+    # sanity: input has no label attribute
+    expect_null(attr(unlabeled_df$AVAL, "label"))
+    unlabeled <- shiny::reactive(list(conc = list(data = unlabeled_df)))
+
+    shiny::testServer(
+      tlg_module_server,
+      args = list(
+        data        = unlabeled,
+        type        = "graph",
+        render_list = capture_fn,
+        options     = list()
+      ),
+      {
+        session$setInputs(entries_per_page = "All")
+        session$elapse(800)         # advance past debounce(750)
+        session$flushReact()
+        tlg_list()                  # force evaluation
+        expect_false(is.null(captured))
+        expect_equal(attr(captured$AVAL, "label"), "Analysis Value")
+      }
+    )
+  })
+
+  it("current_page_items() returns the slice for the current page", {
+    render_5 <- function(data, ...) as.list(paste0("p", 1:5))
+    shiny::testServer(
+      tlg_module_server,
+      args = list(
+        data        = test_data,
+        type        = "graph",
+        render_list = render_5,
+        options     = list()
+      ),
+      {
+        session$setInputs(entries_per_page = 2)
+        session$elapse(800)
+        session$flushReact()
+        expect_equal(current_page_items(), list("p1", "p2"))
+
+        session$setInputs(next_page = 1)
+        session$elapse(800)
+        session$flushReact()
+        expect_equal(current_page_items(), list("p3", "p4"))
+      }
+    )
+  })
 })


### PR DESCRIPTION
## Issue

Closes #1336

> Based off `main` (not the stacked #1343/#1356 work).

## Description

Fixes two related bugs in TLG graph title/label handling (present on `main`, not regressions from #1316):

- **Custom title not applied on combined plots (`pkcg02`):** graphs were rendered by returning raw `plotly` widgets from a `renderUI`, which don't redraw in place when an option changes (the custom title only appeared after switching to another figure and back). Each plot now renders through its own `plotly::plotlyOutput` / `renderPlotly` pair (one slot per plot, tracked by a high-water mark), so `plotly` owns the widget lifecycle and title/subtitle/footnote edits apply immediately!
- **`!COLUMN` label syntax no longer resolving:** the PKNCA/dplyr processing pipeline strips column `label` attributes from `conc$data`, so `parse_annotation()` fell back to the raw column name (e.g. `!AVALU` → `AVALU`). Labels are now re-applied via `apply_labels()` at the TLG data boundary (in `tlg_list`) before rendering, restoring `!COLUMN` across title, subtitle, footnote, and axis inputs.

Listing rendering is unchanged; no changes to the plotting functions themselves.

## Definition of Done

- [x] Custom titles apply immediately when the user finishes editing the input (no figure-switching needed)
- [x] `!COLUMN` syntax resolves to the column's label attribute (e.g. `!AVALU` → "Analysis Value Unit")
- [x] Regression tests added for label restoration and page slicing

## How to test

1. Upload a dataset and run NCA so the Graphs tab populates.
2. Go to **TLG > Order details**, select **pkcg02 – Combined Linear**, click **Submit Order Details**, and open the **Graphs** tab.
3. Enter a custom **Title** (e.g. `My Combined Plot`) and click off the field and the plot title updates immediately, without switching figures.
4. In the **Subtitle** (or Title/Footnote), enter `!AVALU` and it should render "Analysis Value Unit", not the literal `!AVALU` or bare `AVALU`.
5. Sanity check: repeat on **pkcg01** and **pkcg03**, page through plots, and confirm Listings still display.

## Contributor checklist
- [x] Code passes lintr checks
- [ ] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)
- [ ] If any `.scss` change was done, run `data-raw/compile_css.R`
- [ ] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`
