### PR TITLE
docs: fix typos in R comments (disappear, necessary)

### DIFF
--- a/R/PKNCA.R
+++ b/R/PKNCA.R
@@ -454,7 +454,7 @@ PKNCA_calculate_nca <- function(pknca_data, blq_rule = NULL) { # nolint: object_
         # TODO (Gerardo): This is a temporary fix to prevent issues when datasets
         # drop values, this was only affecting BLQ branch (#139) but not main, related
         # with pk.nca.interval() for how we deal with it in aNCA. If BLQ imputation is
-        # done, this values dissappear and then it is considered that those times were
+        # done, this values disappear and then it is considered that those times were
         # also NA, which causes the error. In PKNCA dropping in imputation works fine,
         # but aNCA might be doing something special we are missing
         d_na <- data.frame(

--- a/R/g_pkcg.R
+++ b/R/g_pkcg.R
@@ -163,7 +163,7 @@ pkcg01 <- function(
       aes(color = !!sym(color_var)) +
       theme(legend.position = "none")
 
-    # Add color legend only when neccessary
+    # Add color legend only when necessary
     if (length(unique(adnca[[color_var]])) > 1) {
 
       # Make sure the variable is interpreted as a factor


### PR DESCRIPTION
Fixes two spelling typos in code comments.

- `dissappear` -> `disappear` in `R/PKNCA.R`
- `neccessary` -> `necessary` in `R/g_pkcg.R`

Closes #1362