### PR TITLE
Fix typos in code comments (dissappear -> disappear, neccessary -> necessary)

### DIFF
--- a/R/PKNCA.R
+++ b/R/PKNCA.R
@@ -454,7 +454,7 @@ PKNCA_calculate_nca <- function(pknca_data, blq_rule = NULL) { # nolint: object_
         # TODO (Gerardo): This is a temporary fix to prevent issues when datasets
         # drop values, this was only affecting BLQ branch (#139) but not main, related
         # with pk.nca.interval() for how we deal with it in aNCA. If BLQ imputation is
-        # done, this values dissappear and then it is considered that those times were
+        # done, this values disappear and then it is considered that those times were
         # also NA, which causes the error. In PKNCA dropping in imputation works fine,
         # but aNCA might be doing something special we are missing
         d_na <- data.frame(

--- a/R/g_pkcg.R
+++ b/R/g_pkcg.R
@@ -163,7 +163,7 @@ pkcg01 <- function(
       aes(color = !!sym(color_var)) +
       theme(legend.position = "none")
 
-    # Add color legend only when neccessary
+    # Add color legend only when necessary
     if (length(unique(adnca[[color_var]])) > 1) {
 
       # Make sure the variable is interpreted as a factor


### PR DESCRIPTION
## Issue

Closes #1362

## Description

Fix two typos in code comments:
- `R/PKNCA.R:457`: dissappear → disappear
- `R/g_pkcg.R:166`: neccessary → necessary

Comment-only change, no functional impact.

## Definition of Done

- [x] Both typos fixed
- [x] `lintr` passes (see note)

## How to test

N/A — comment-only change.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests (N/A)
- [x] New logic is documented (N/A)
- [x] App or package changes are reflected in NEWS (N/A)
- [x] Package version is incremented (N/A)
- [x] R script works with the new implementation (if applicable)
- [x] Settings upload works with the new implementation (if applicable)
- [x] If any `.scss` change was done, run `data-raw/compile_css.R`
- [x] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`

## Notes to reviewer

The `Lint / Lint` check failure is unrelated to this PR — it is caused by an unpinned lintr upgrading to 3.4.0 and flagging pre-existing code across the repo. Tracked in #1398.