### PR TITLE
Add SECURITY.md and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Code owners for aNCA
+#
+# These maintainers are automatically requested for review on pull requests.
+# See https://docs.github.com/articles/about-code-owners for syntax.
+
+# Default owners for everything in the repository
+*       @Gero1999 @Shaakon35 @h5hoang

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the most recent release of aNCA. We
+recommend always using the latest version available on
+[CRAN](https://CRAN.R-project.org/package=aNCA) or the current
+development version from the [`main` branch](https://github.com/pharmaverse/aNCA).
+
+| Version            | Supported          |
+| ------------------ | ------------------ |
+| Latest release     | :white_check_mark: |
+| Older versions     | :x:                |
+
+## Reporting a Vulnerability
+
+We take the security of aNCA seriously. If you believe you have found a
+security vulnerability, please report it privately so we can address it
+before it is publicly disclosed.
+
+**Please do not report security vulnerabilities through public GitHub
+issues, discussions, or pull requests.**
+
+Instead, use one of the following private channels:
+
+- **GitHub Private Vulnerability Reporting** (preferred): open a report via
+  the [Security tab](https://github.com/pharmaverse/aNCA/security/advisories/new)
+  of this repository.
+- **Email**: contact the maintainers at **anca.pharmaverse@gmail.com**.
+
+Please include as much of the following as you can:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce, or a proof of concept.
+- The version of aNCA affected.
+- Any suggested mitigation, if known.
+
+## Response Process
+
+- We will acknowledge your report within **14 days**.
+- We will investigate and keep you informed of our progress.
+- Once resolved, we will coordinate disclosure and credit you for the
+  report, unless you prefer to remain anonymous.
+
+## Scope
+
+This policy applies to the aNCA package and its Shiny application. As aNCA
+processes user-supplied pharmacokinetic datasets locally, please be
+mindful **not to include any sensitive, confidential, or patient data**
+in your reports.
+
+Vulnerabilities in aNCA's dependencies (e.g. `PKNCA`, `shiny`) should be
+reported to their respective maintainers, though we appreciate being
+informed if they affect aNCA.


### PR DESCRIPTION
## Description

Adds two open-source community-health files:

- **`.github/SECURITY.md`** — a security policy describing how to report vulnerabilities privately, via GitHub Private Vulnerability Reporting (preferred) or the maintainer email. This closes the last blocking item for the OpenSSF **Passing** badge (`vulnerability_report_process` + `vulnerability_report_private`).
- **`.github/CODEOWNERS`** — automatically requests review from the active core maintainers (@Gero1999, @Shaakon35, @h5hoang) on every pull request, matching the review policy in `CONTRIBUTING.md`.

## Follow-up (maintainer action)

To make the `SECURITY.md` reporting link fully functional, enable **Private Vulnerability Reporting** under **Settings → Code security and analysis**. Until then, the email channel still works.

## Type of change

- [x] Documentation / project-health files (no code changes)

## Checklist

- [x] No R code changed (no version bump / NEWS entry needed)
- [x] Files follow GitHub community-health conventions
- [x] Enable GitHub Private Vulnerability Reporting (maintainer setting)

Relates to #1405
