### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/data-raw-check.yml
+++ b/.github/workflows/data-raw-check.yml
@@ -38,16 +38,16 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ inputs.r-version }}
           use-public-rspm: true
 
       - name: Install R Dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Run data-raw/rebuild.R
         run: source("data-raw/rebuild.R")

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -46,16 +46,16 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ inputs.r-version }}
           use-public-rspm: true
 
       - name: Install R Dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: |
             local::.
@@ -64,7 +64,7 @@ jobs:
 
       - name: Changed files
         id: files
-        uses: Ana06/get-changed-files@v2.2.0
+        uses: Ana06/get-changed-files@e0c398b7065a8d84700c471b6afc4116d1ba4e96 # v2.2.0
         with:
           format: "json"
           filter: "*"

--- a/.github/workflows/man-pages.yml
+++ b/.github/workflows/man-pages.yml
@@ -36,16 +36,16 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ inputs.r-version }}
           use-public-rspm: true
 
       - name: Install R Dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           # roxygen2 pinned to match the version used locally by developers.
           # Update this when the team upgrades to a newer roxygen2 version.

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -21,15 +21,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
-      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
+      - uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
@@ -40,7 +40,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e # v4.5.0
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -39,16 +39,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ matrix.config.r }}
           use-public-rspm: true
 
       - name: Install R Dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: any::rcmdcheck
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -46,19 +46,19 @@ jobs:
       !contains(github.event.commits[0].message, '[skip spellcheck]')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ inputs.r-version }}
           use-public-rspm: true
 
       - name: Install R Dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Run Spellcheck
-        uses: insightsengineering/r-spellcheck-action@v3
+        uses: insightsengineering/r-spellcheck-action@33b8e19df4227812758fadd88d50b710c7620e1f # v3
         with:
           additional_options: ""
           exclude: "${{ inputs.exclude }}"

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -19,18 +19,18 @@ jobs:
       coverage-percent: ${{ steps.set-coverage-percentage.outputs.coverage-percentage }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Pandoc
-        uses: r-lib/actions/setup-pandoc@v2
+        uses: r-lib/actions/setup-pandoc@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           use-public-rspm: true
 
       - name: Install R Dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: |
             local::.
@@ -73,7 +73,7 @@ jobs:
 
       - name: Check whether coverage reports exists
         id: check_coverage_reports
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@f02338908d150e00a4b8bebc2dad18bd9e5229b0 # v1
         with:
           files: "coverage.xml, coverage.txt, coverage-report.html"
 
@@ -84,7 +84,7 @@ jobs:
 
       - name: Generate Coverage Summary Report
         if: steps.check_coverage_reports.outputs.files_exists == 'true' && github.event_name == 'pull_request'
-        uses: irongut/CodeCoverageSummary@v1.2.0
+        uses: irongut/CodeCoverageSummary@5088d5eb315a46ff785c607078606c0b9107e0b6 # v1.2.0
         with:
           filename: coverage.xml
           badge: true
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload report for review
         if: steps.check_coverage_reports.outputs.files_exists == 'true' && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report
           path: "coverage-report.html"
@@ -106,7 +106,7 @@ jobs:
 
       - name: Add Coverage PR Comment
         if: steps.check_coverage_reports.outputs.files_exists == 'true' && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         with:
           header: code-coverage
           path: code-coverage-results.md
@@ -118,14 +118,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout the badges branch in repo
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: badges
           path: badges
 
       # Use the output from the `coverage` step
       - name: Generate the badge SVG image
-        uses: emibcn/badge-action@v1
+        uses: emibcn/badge-action@2f70f25eed9a1b71ffb09535523b460cc8c16d04 # v1
         id: badge
         with:
           label: "Test Coverage"
@@ -154,7 +154,7 @@ jobs:
           git commit -m "Add/Update badge" || true
 
       - name: Push badges
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: badges

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install system dependencies (Chrome)
         env:
@@ -45,13 +45,13 @@ jobs:
           sudo apt-get install -qq -y google-chrome-stable
 
       - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+        uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           r-version: ${{ inputs.r-version }}
           use-public-rspm: true
 
       - name: Install R Dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
+        uses: r-lib/actions/setup-r-dependencies@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
           extra-packages: |
             local::.


### PR DESCRIPTION
## Description

Pins all third-party GitHub Actions to full commit SHAs (with the version as a trailing comment) instead of mutable version tags. Identified during an [OpenSSF Best Practices Badge](https://www.bestpractices.dev) review (see #1405).

### Why

Version tags like `@v4.2.2` are **mutable** — the action's owner (or an attacker who compromises that account) can repoint the tag to different code, which our CI would then run automatically. Our workflows' `GITHUB_TOKEN` can write to:

- the repository contents,
- the `badges` branch (coverage badge),
- the **pkgdown website** (gh-pages).

Pinning to an immutable SHA removes the "hijacked/repointed action tag" class of supply-chain risk. This aligns with the OpenSSF Scorecard **Pinned-Dependencies** check.

### What changed

- Every external `uses:` reference now uses a 40-char commit SHA, e.g.:
  ```yaml
  uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
  ```
- Local reusable-workflow calls (`./.github/workflows/*.yml`) are intentionally left as relative references (correct convention — they are versioned with this repo).
- No workflow logic, triggers, or indentation changed — only the pinned refs.

### Actions pinned

| Action | Version | SHA |
| --- | --- | --- |
| actions/checkout | v4.2.2 | `11bd719` |
| actions/upload-artifact | v4 | `ea165f8` |
| r-lib/actions/* | v2 | `d3c5be5` |
| marocchino/sticky-pull-request-comment | v2 | `7737449` |
| irongut/CodeCoverageSummary | v1.2.0 | `5088d5e` |
| insightsengineering/r-spellcheck-action | v3 | `33b8e19` |
| emibcn/badge-action | v1 | `2f70f25` |
| andstor/file-existence-action | v1 | `f023389` |
| ad-m/github-push-action | master | `881a632` |
| JamesIves/github-pages-deploy-action | v4.5.0 | `65b5dfd` |
| Ana06/get-changed-files | v2.2.0 | `e0c398b` |

### Maintenance note

Recommend adding Dependabot (`github-actions` ecosystem) in a follow-up so these SHAs are kept up to date automatically.

## Type of change

- [x] CI / infrastructure (no package code changed)

## Checklist

- [x] No R code changed (no version bump / NEWS entry needed)
- [x] Only pinned refs changed; workflow logic untouched
- [x] CI passes on this PR (confirms the pinned SHAs resolve correctly)

Relates to #1405
