### PR TITLE
Set least-privilege permissions on workflows

### DIFF
--- a/.github/workflows/data-raw-check.yml
+++ b/.github/workflows/data-raw-check.yml
@@ -28,6 +28,9 @@ concurrency:
   group: data-raw-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   data-raw-check:
     name: Data Raw

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -36,6 +36,10 @@ concurrency:
   group: lint-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,10 @@ concurrency:
 env:
   R_VERSION: "release"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   get_r_version:
     name: Get R version

--- a/.github/workflows/man-pages.yml
+++ b/.github/workflows/man-pages.yml
@@ -26,6 +26,9 @@ concurrency:
   group: roxygen-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Roxygen

--- a/.github/workflows/r-cmd-check.yml
+++ b/.github/workflows/r-cmd-check.yml
@@ -17,6 +17,9 @@ concurrency:
   group: r-cmd-check-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -36,6 +36,9 @@ concurrency:
   group: spelling-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     name: Spellcheck

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -9,10 +9,16 @@ on:
 
 name: Code Coverage
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     name: Test Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     outputs:
@@ -116,6 +122,8 @@ jobs:
     name: Generate badge for coverage
     needs: [coverage]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout the badges branch in repo
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ concurrency:
   group: tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Tests


### PR DESCRIPTION
## Description

Declares explicit least-privilege `permissions:` for the `GITHUB_TOKEN` in each workflow. review (see #1405).

### Why

When a workflow does not declare `permissions:`, its `GITHUB_TOKEN` gets the repository's broad default scope (often read/write). If any action in that workflow were compromised, the token could write to the repo, the coverage badge branch, or the pkgdown website. Scoping each workflow to the minimum it needs limits the blast radius of such an incident. This aligns with the OpenSSF Scorecard **Token-Permissions** check.

### What changed

Read-only check workflows now default to `contents: read`:

- `test.yml`, `r-cmd-check.yml`, `spellcheck.yml`, `data-raw-check.yml`, `man-pages.yml`
- `lintr.yml` and `main.yml` also get `pull-requests: read` (lintr reads changed files via the PR)

Workflows that genuinely write keep only the scopes they need, declared per job:

- `test-coverage.yml`: top-level `contents: read`; `coverage` job `pull-requests: write` (PR coverage comment); `badge` job `contents: write` (pushes badge to the `badges` branch)
- `pkgdown.yml`: already least-privilege (`read-all` top-level, `contents: write` on the deploy job) — left unchanged

Only `permissions:` blocks were added — no workflow logic, triggers, or steps changed (8 files, 31 insertions).

## Type of change

- [x] CI / infrastructure (no package code changed)

## Checklist

- [x] No R code changed (no version bump / NEWS entry needed)
- [x] Only `permissions:` blocks added; workflow logic untouched
- [x] CI passes on this PR (confirms coverage comment + badge push still work under the scoped tokens)

Relates to #1405
