### PR TITLE
fixed: issue #1365

### DIFF
--- a/R/run_app.R
+++ b/R/run_app.R
@@ -50,10 +50,12 @@
 #'   run_app(settings = "/path/to/settings.yaml", settings_version = "NCA draft")
 #' }
 #' @export
+
+max_upload_size_mb <- 30
 run_app <- function(datapath = NULL, settings = NULL,
                     settings_version = 1L, ...) {
   # Increase max upload size to 30 MB
-  options(shiny.maxRequestSize = 30 * 1024^2)
+  options(shiny.maxRequestSize = max_upload_size_mb * 1024^2)
   if (!is.null(datapath)) {
     stopifnot(
       "Data file does not exist" = file.exists(datapath),

--- a/inst/shiny/modules/tab_data/data_upload.R
+++ b/inst/shiny/modules/tab_data/data_upload.R
@@ -15,7 +15,10 @@ data_upload_ui <- function(id) {
     div(
       class = "upload-container",
       id = ns("upload_container"),
-      p("Upload your PK dataset and Settings file (optional)."),
+      p("Upload your PK dataset and Settings file (optional).",
+        tags$br(),
+        tags$small(style = "color: #6c757d; display: block; margin-top: 4px;",
+                   sprintf("Maximum upload size: %s MB", max_upload_size_mb))),
       fileInput(
         ns("data_upload"),
         width = "50%",


### PR DESCRIPTION
## Issue

Closes #1365 

## Description

Added a helper text that states the maximum upload limit

Additionally, sourced the limit from a single constant so the UI text and run_app.R stay in sync

## Definition of Done

- [x] Max upload size is visible in the upload UI
- [x] Value matches the actual shiny.maxRequestSize setting


## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [ ] New logic covered by unit tests
- [ ] New logic is documented
- [ ] App or package changes are reflected in NEWS
- [ ] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)
- [ ] If any `.scss` change was done, run `data-raw/compile_css.R`
- [ ] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`