### PR TITLE
Refresh stale TODO comments whose referenced issues have closed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9190
+Version: 0.1.0.9191
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # aNCA (development version)
 
+## Maintenance
+
+* Refresh stale in-code TODO comments whose referenced issues have since closed: the slope-selector `na.omit` guard is now documented as a defensive safety net (#641 reworked the reactivity), and the BLQ dropped-record workaround points to the current imputation-consistency issues (#1057, #1442, #1443) instead of the closed #139. Clarified why meta-mapping keys are excluded in `apply_mapping()`. Part of the TODO inventory in #1447
+
 ## Bug Fixes
 
 * Mean concentration plots no longer drop timepoints that are well under the BLQ threshold: the BLQ ratio counted flagged records against a denominator of distinct subjects, so a subject contributing several records to a timepoint could push the ratio above 1. It is now counted per subject on both sides (#1356)

--- a/R/PKNCA.R
+++ b/R/PKNCA.R
@@ -451,12 +451,13 @@ PKNCA_calculate_nca <- function(pknca_data, blq_rule = NULL) { # nolint: object_
           conc.na = "drop"
         )
 
-        # TODO (Gerardo): This is a temporary fix to prevent issues when datasets
-        # drop values, this was only affecting BLQ branch (#139) but not main, related
-        # with pk.nca.interval() for how we deal with it in aNCA. If BLQ imputation is
-        # done, this values disappear and then it is considered that those times were
-        # also NA, which causes the error. In PKNCA dropping in imputation works fine,
-        # but aNCA might be doing something special we are missing
+        # BLQ imputation (shipped via #139) can drop concentration records.
+        # aNCA's pk.nca.interval() handling then treats those dropped times as
+        # NA, which errors out. Re-insert the dropped times with NA conc so PKNCA
+        # drops them itself (which works cleanly) instead of aNCA mishandling
+        # them. This is a stopgap for a mismatch between how PKNCA and aNCA drop
+        # values during imputation; the imputation-consistency work in #1057,
+        # #1442, and #1443 tracks resolving it properly.
         d_na <- data.frame(
           conc = rep(NA, sum(!time %in% d$time)), # PKNCA will drop the value
           time = time[!time %in% d$time]

--- a/R/apply_mapping.R
+++ b/R/apply_mapping.R
@@ -57,8 +57,11 @@ apply_mapping <- function(
 
   new_dataset <- dataset
 
-  ####### TODO (Gerardo): This would be better to be explicit outside the function
-  # Grouping_Variables should not be renamed
+  # Drop meta-mapping keys that are not column renames: Grouping_Variables,
+  # Metabolites, and NCAwXRS select existing columns / drive downstream options
+  # rather than renaming a source column, so they must not flow into the rename
+  # step below. Ideally the caller would pass only true rename pairs so this
+  # filtering could live outside apply_mapping().
   mapping <- mapping[!names(mapping) %in% c("Grouping_Variables", "Metabolites", "NCAwXRS")]
 
   # Special case: If ADOSEDUR is not mapped, we assume is 0
@@ -85,7 +88,6 @@ apply_mapping <- function(
       )
     )
   }
-  ################################################################################
 
   # If a variable to map is not a column in the data, assume is the value to use for its creation
   mappings_not_in_data <- mapping[!unname(mapping) %in% names(dataset) & mapping != ""]

--- a/R/utils-slope_selector.R
+++ b/R/utils-slope_selector.R
@@ -10,13 +10,13 @@ update_pknca_with_rules <- function(data, slopes) {
   exclude_hl_col <- data$conc$columns$exclude_half.life
   include_hl_col <- data$conc$columns$include_half.life
 
-  #####################################################
-  # TODO: Make a better fix to understand why slopes is constructed 2 times
-  # when adding exclusion, running NCA and then removing slope (#641)
-
-  # Make sure when rows are removed no NA value is left
+  # Defensive guard: drop any incomplete slope rules before applying them.
+  # Editing the manual-slopes table (add exclusion -> run NCA -> remove a slope)
+  # can momentarily leave rows with NA cells; na.omit keeps those partial rows
+  # from producing invalid ranges below. The slope-selector reactivity was
+  # reworked in #641, so the original "slopes constructed twice" behaviour may
+  # no longer occur -- this guard is cheap and kept as a safety net.
   slopes <- na.omit(slopes)
-  #####################################################
 
   for (i in seq_len(nrow(slopes))) {
     # Determine the time range for the points adjusted


### PR DESCRIPTION
## Issue

Part of the TODO inventory tracked in #1447.

## Description

Three in-code TODO comments referenced issues that have since closed, leaving misleading notes. This PR refreshes them (comment-only, no runtime behavior change):

- **`R/utils-slope_selector.R`** — the "slopes constructed twice (#641)" note predates the slope-selector reactivity rework in #641. The `na.omit()` call is now documented as a defensive guard against partial rows from in-progress manual-slopes table edits.
- **`R/PKNCA.R`** — the BLQ dropped-record "temporary fix" pointed at the now-closed #139. The comment now explains the PKNCA/aNCA drop mismatch it works around and points to the open imputation-consistency issues #1057, #1442, #1443.
- **`R/apply_mapping.R`** — replaced a terse divider TODO with an explanation of why `Grouping_Variables`, `Metabolites`, and `NCAwXRS` are excluded from the rename step, and removed the orphaned divider line.

## Definition of Done

- Stale TODO comments referencing closed issues (#641, #139) are refreshed or re-pointed to live issues.
- No runtime behavior changes (comment-only edits).

## Contributor checklist

- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests (n/a — comment-only, no logic change)
- [x] New logic is documented (n/a — comment-only)
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [x] R script works with the new implementation (n/a)
- [x] Settings upload works with the new implementation (n/a)

## Notes to reviewer

These are documentation-only changes to clarify or re-point stale TODOs whose issues have closed. No executable code was modified, so CI (lintr + tests) is the verification that nothing was disturbed.
