### PR TITLE
fix: shorten PKNCA parameter descriptions to the SDTM 40-character limit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Maintenance
 
+* Shortened the `desc` strings registered with `PKNCA::add.interval.col()` for `ertlst`, `ertmax`, and `volpk` to 40 characters or fewer, as SDTM requires. PKNCA 0.12.1.9000 warns about longer descriptions, and an earlier development version rejected them outright, which made aNCA fail to install (#1102)
+
 * Refresh stale in-code TODO comments whose referenced issues have since closed: the slope-selector `na.omit` guard is now documented as a defensive safety net (#641 reworked the reactivity), and the BLQ dropped-record workaround points to the current imputation-consistency issues (#1057, #1442, #1443) instead of the closed #139. Clarified why meta-mapping keys are excluded in `apply_mapping()`. Part of the TODO inventory in #1447
 
 ## Bug Fixes

--- a/R/PKNCA_extra_parameters.R
+++ b/R/PKNCA_extra_parameters.R
@@ -35,7 +35,7 @@ PKNCA::add.interval.col("ertlst",
                  FUN="pk.calc.ertlst",
                  unit_type="time",
                  pretty_name="Tlast excretion rate",
-                 desc="The midpoint collection time of the last measurable excretion rate (typically in urine or feces)")
+                 desc="Midpoint time of last excretion rate")
 
 PKNCA::PKNCA.set.summary(
   name="ertlst",
@@ -122,7 +122,7 @@ PKNCA::add.interval.col(
   FUN = "pk.calc.ertmax",
   unit_type = "time",
   pretty_name = "Tmax excretion rate",
-  desc = "The midpoint collection time of the maximum excretion rate (typically in urine or feces)"
+  desc = "Midpoint time of max excretion rate"
 )
 
 PKNCA::PKNCA.set.summary(
@@ -201,7 +201,7 @@ PKNCA::add.interval.col(
   values = c(FALSE, TRUE),
   unit_type = "volume",
   pretty_name = "Total Urine Volume",
-  desc = "The sum of urine volumes for the interval"
+  desc = "Sum of urine volumes in the interval"
 )
 PKNCA::PKNCA.set.summary(
   name = "volpk",


### PR DESCRIPTION
Part of #1102.

The `desc` strings registered with `PKNCA::add.interval.col()` for `ertlst`, `ertmax`, and `volpk` are 96, 88, and 41 characters. SDTM allows at most 40.

PKNCA 0.12.1.9000 warns on longer descriptions, naming the parameter and the offending text. An earlier development build enforced the limit with an assertion instead, which made aNCA **fail to install outright** — `add.interval.col()` runs at load time, so the error surfaced during lazy loading before any aNCA code could run.

Only the registered `desc` values change. The roxygen `@title` and `@return` prose is not SDTM-constrained and is left alone, so no documentation needs regenerating.