### PR TITLE
test: give the predose fixture the half-life columns its PKNCAconc names

### DIFF
--- a/tests/testthat/test-intervals.R
+++ b/tests/testthat/test-intervals.R
@@ -216,7 +216,9 @@ describe("format_pkncadata_intervals", {
       DOSEA = 10,
       ROUTE = "extravascular",
       ADOSEDUR = 0,
-      AVAL = c(0, 5, 3, 1)
+      AVAL = c(0, 5, 3, 1),
+      exclude_half.life = FALSE,
+      include_half.life = NA
     )
 
     df_conc_pd <- format_pkncaconc_data(


### PR DESCRIPTION
Follow-up to 571f624 on `1102-bug/pknca-dev-compat`.

That commit gave the `ADNCA` fixture in `test-intervals.R` `exclude_half.life` and `include_half.life` so its `PKNCAconc()` calls resolve under dev PKNCA, but `predose_adnca` — defined separately at line 204 of the same file — was not covered. It feeds `format_pkncaconc_data()` and then a `PKNCAconc()` call naming `exclude_half.life`, so it still fails:

```
format_pkncadata_intervals / anchors start to C1, not the predose sample, when start_from_last_dose is FALSE
Error in `setAttributeColumn()`: The exclude_half.life column ('exclude_half.life') does not exist in the data
```

Adds the same two columns in the same form as the `ADNCA` fixture above it.