### PR TITLE
Add ci-spellcheck-triage, ci-lintr-triage and ci-roxygen-triage agent skills

### DIFF
--- a/.github/skills/ci-lintr-triage/SKILL.md
+++ b/.github/skills/ci-lintr-triage/SKILL.md
@@ -58,35 +58,34 @@ single pass.
 
 ### 2. Consult `.lintr` for the expected standard
 
-Before editing, read the repo's `.lintr` to know exactly what is expected — the
-project customises several linters, so the default lintr behaviour is not the
-source of truth. Current configuration to be aware of:
+**Always read the repo's `.lintr` — it is the source of truth.** The project
+customises several linters, so lintr's defaults do not apply, and any thresholds
+(line length, cyclomatic complexity, etc.) must be taken from `.lintr` at the
+time you run, not assumed. Map each failing `linter` name to its configured rule
+there.
 
-- `line_length_linter(100)` — max line length is **100** characters.
-- `object_name_linter(styles = c("snake_case", "SNAKE_CASE"))` — names must be
-  snake_case or SNAKE_CASE.
-- `pipe_consistency_linter("%>%")` — use the magrittr `%>%` pipe, not `|>`.
-- `assignment_linter(operator = c("<-", "<<-"))` — assign with `<-`/`<<-`, not `=`.
-- `return_linter(return_style = "implicit")` — do not use an explicit final
-  `return(...)`; let the last expression be the value.
-- `seq_linter()` — use `seq_len()` / `seq_along()` instead of `1:n`.
-- `cyclocomp_linter(complexity_limit = 15)` — function cyclomatic complexity
-  must be <= 15.
-- `object_usage_linter = NULL` — this linter is disabled; do not chase it.
-- `exclusions` — some paths are excluded from linting entirely; do not "fix"
+Some facts about this config are non-obvious from a lint message and easy to get
+wrong, so keep them in mind (but still confirm against `.lintr`):
+
+- The pipe style is enforced — use the magrittr `%>%` pipe, not `|>`.
+- Assignment style is enforced — assign with `<-`/`<<-`, not `=`.
+- Return style is implicit — do not add an explicit final `return(...)`.
+- Object names must follow the configured case styles (snake_case / SNAKE_CASE).
+- `object_usage_linter` is **disabled** — do not chase usage lints.
+- `exclusions` lists paths excluded from linting entirely — do **not** "fix"
   lints in excluded files.
 
-Always re-read `.lintr` in case these values change; treat the file as the
-authority for the standard, and map each failing `linter` name to its rule
-there.
+For any rule with a numeric threshold (e.g. line length, cyclocomp), read the
+exact value from `.lintr` rather than relying on memory — these are the most
+likely to change.
 
 ### 3. Fix the affected code to satisfy the linter
 
 For each lint, edit the named file at the named line so it conforms to the
 standard from step 2, keeping behaviour identical. Typical fixes:
 
-- **`line_length_linter`** — break the line under 100 chars (wrap arguments, a
-  pipe step, or a long string) without changing logic.
+- **`line_length_linter`** — break the line under the configured limit (wrap
+  arguments, a pipe step, or a long string) without changing logic.
 - **`pipe_continuation_linter`** — put each pipe step on its own line with a
   newline after `%>%` when the pipeline spans multiple lines, e.g.
   `bind_rows(...) %>%` then `  select(-VOL)` on the next line.
@@ -98,9 +97,10 @@ standard from step 2, keeping behaviour identical. Typical fixes:
   expression as the last line.
 - **`seq_linter`** — replace `1:length(x)` with `seq_along(x)` and `1:n` with
   `seq_len(n)`.
-- **`cyclocomp_linter`** — reduce branching by extracting a helper function or
-  simplifying control flow; this is a real refactor, so keep it behaviour-
-  preserving and add/adjust tests if logic moves.
+- **`cyclocomp_linter`** — the function exceeds the configured complexity limit;
+  reduce branching by extracting a helper or simplifying control flow. This is a
+  real refactor, so keep it behaviour-preserving and add/adjust tests if logic
+  moves.
 
 Fix the code, not the config: do not raise limits, disable linters, or add
 paths to `exclusions` to make a genuine lint pass. Changing `.lintr` also has a
@@ -117,13 +117,13 @@ verification is the re-run of the lint job in CI. Before handing off:
 - Re-check each reported `file:line` now conforms to the rule from `.lintr`.
 - For renames, confirm every reference was updated.
 - Watch for fixes that introduce a *new* lint (e.g. a rewrap that pushes another
-  line over 100 chars).
+  line over the length limit).
 
 Then report per lint: file:line, the linter, and the fix applied. Example:
 
 ```
 - test-detect_study_types.R:179 pipe_continuation_linter -> put select(-VOL) on its own line after %>%
-- R/foo.R:42 line_length_linter -> wrapped the call arguments to stay under 100 chars
+- R/foo.R:42 line_length_linter -> wrapped the call arguments to stay under the limit
 ```
 
 ## Notes and limits

--- a/.github/skills/ci-lintr-triage/SKILL.md
+++ b/.github/skills/ci-lintr-triage/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: ci-lintr-triage
+description: >
+  Resolve failing Lint / Lint CI jobs. Use when a PR's lintr check fails.
+  Reads each lint from the CI log (linter, file, line, message), consults
+  the project's .lintr config for the expected standards, and fixes the
+  affected code to satisfy the linter.
+---
+
+# CI Lintr Triage
+
+The **Lint / Lint** job runs `lintr::lint_package()` and fails when any lint is
+reported. Each lint names the offending file, line, and the specific linter that
+fired. The expected standards come from the repo's `.lintr` config, not from
+lintr's defaults alone.
+
+This skill makes the fix repeatable: read the CI result, look up what the
+relevant linter expects in `.lintr`, and correct the affected files so the code
+conforms — without weakening the config.
+
+## When to use
+
+- A PR's `Lint / Lint` check is red.
+- Someone asks "fix the lint failure on PR #NNN".
+
+Do not use this for spellcheck, tests, or roxygen failures — those are different
+checks (see `ci-spellcheck-triage` for spelling).
+
+## Inputs you need
+
+- The PR number (or the workflow run / job id) whose lint job failed.
+
+## Workflow
+
+### 1. Read the failing job log and extract every lint
+
+Find the lint job for the PR's latest run and read its log. `lintr` prints each
+lint as a structured entry, for example:
+
+```
+[[1]]
+$filename      "tests/testthat/test-detect_study_types.R"
+$line_number   179
+$column_number 7
+$type          "style"
+$message       "Put a space before `%>%` and a new line after it, unless the full pipeline fits on one line."
+$line          "    ) %>% select(-VOL)"
+$linter        "pipe_continuation_linter"
+```
+
+Collect **every** entry — `lintr` can report many at once. For each, record:
+`filename`, `line_number`, `column_number`, the `linter` name, and the `message`.
+If the log is long, read from the tail so the printed lints (just before the
+`stop("Lints detected...")`) are visible.
+
+Do not stop after one lint. Resolve the full list so the next run is green in a
+single pass.
+
+### 2. Consult `.lintr` for the expected standard
+
+Before editing, read the repo's `.lintr` to know exactly what is expected — the
+project customises several linters, so the default lintr behaviour is not the
+source of truth. Current configuration to be aware of:
+
+- `line_length_linter(100)` — max line length is **100** characters.
+- `object_name_linter(styles = c("snake_case", "SNAKE_CASE"))` — names must be
+  snake_case or SNAKE_CASE.
+- `pipe_consistency_linter("%>%")` — use the magrittr `%>%` pipe, not `|>`.
+- `assignment_linter(operator = c("<-", "<<-"))` — assign with `<-`/`<<-`, not `=`.
+- `return_linter(return_style = "implicit")` — do not use an explicit final
+  `return(...)`; let the last expression be the value.
+- `seq_linter()` — use `seq_len()` / `seq_along()` instead of `1:n`.
+- `cyclocomp_linter(complexity_limit = 15)` — function cyclomatic complexity
+  must be <= 15.
+- `object_usage_linter = NULL` — this linter is disabled; do not chase it.
+- `exclusions` — some paths are excluded from linting entirely; do not "fix"
+  lints in excluded files.
+
+Always re-read `.lintr` in case these values change; treat the file as the
+authority for the standard, and map each failing `linter` name to its rule
+there.
+
+### 3. Fix the affected code to satisfy the linter
+
+For each lint, edit the named file at the named line so it conforms to the
+standard from step 2, keeping behaviour identical. Typical fixes:
+
+- **`line_length_linter`** — break the line under 100 chars (wrap arguments, a
+  pipe step, or a long string) without changing logic.
+- **`pipe_continuation_linter`** — put each pipe step on its own line with a
+  newline after `%>%` when the pipeline spans multiple lines, e.g.
+  `bind_rows(...) %>%` then `  select(-VOL)` on the next line.
+- **`pipe_consistency_linter`** — replace `|>` with `%>%`.
+- **`assignment_linter`** — replace `=` used for assignment with `<-`.
+- **`object_name_linter`** — rename to snake_case / SNAKE_CASE, updating **all**
+  references to the renamed object.
+- **`return_linter`** — remove a trailing `return(...)`, leaving the bare
+  expression as the last line.
+- **`seq_linter`** — replace `1:length(x)` with `seq_along(x)` and `1:n` with
+  `seq_len(n)`.
+- **`cyclocomp_linter`** — reduce branching by extracting a helper function or
+  simplifying control flow; this is a real refactor, so keep it behaviour-
+  preserving and add/adjust tests if logic moves.
+
+Fix the code, not the config: do not raise limits, disable linters, or add
+paths to `exclusions` to make a genuine lint pass. Changing `.lintr` also has a
+side effect — when `.lintr` is in a PR's changed files, the CI lints the **whole
+package**, not just the diff.
+
+Never use `[skip lint]` to get a green run.
+
+### 4. Verify what you can, and report
+
+You cannot run R, so you cannot run `lintr::lint_package()` locally — final
+verification is the re-run of the lint job in CI. Before handing off:
+
+- Re-check each reported `file:line` now conforms to the rule from `.lintr`.
+- For renames, confirm every reference was updated.
+- Watch for fixes that introduce a *new* lint (e.g. a rewrap that pushes another
+  line over 100 chars).
+
+Then report per lint: file:line, the linter, and the fix applied. Example:
+
+```
+- test-detect_study_types.R:179 pipe_continuation_linter -> put select(-VOL) on its own line after %>%
+- R/foo.R:42 line_length_linter -> wrapped the call arguments to stay under 100 chars
+```
+
+## Notes and limits
+
+- A lint may come from the base branch rather than the PR's diff (especially if
+  `.lintr` changed, which triggers whole-package linting). Note when the cause
+  is inherited.
+- Do not edit generated files under `man/` (see `AGENTS.md`); fix roxygen source
+  in `R/` instead.
+- Prefer the smallest change that satisfies the linter while keeping the code
+  readable and behaviour unchanged.
+
+## References
+
+- `.github/workflows/lintr.yml` — the workflow definition.
+- `.lintr` — the linter configuration (the source of truth for standards).
+- `AGENTS.md` — project conventions (code principles, generated files).

--- a/.github/skills/ci-roxygen-triage/SKILL.md
+++ b/.github/skills/ci-roxygen-triage/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: ci-roxygen-triage
+description: >
+  Resolve failing Roxygen / Man Pages CI jobs. Use when a PR's roxygen check
+  fails because man/ or DESCRIPTION are out of date. Reads the CI diff, traces
+  each stale man page back to its roxygen source in R/, and fixes the source so
+  regeneration would produce the committed output.
+---
+
+# CI Roxygen Triage
+
+The **Roxygen** job (workflow "Man Pages") runs
+`roxygen2::roxygenize('.', roclets = c('rd', 'collate', 'namespace'))` and then
+fails if `man/*` or `DESCRIPTION` differ from what is committed. A failure means
+the generated docs / `NAMESPACE` / collate are out of sync with the roxygen
+comments in `R/`.
+
+The fix is always in the **source** (`R/*.R` roxygen blocks, and the manually
+maintained `NAMESPACE`/`DESCRIPTION` entries the project keeps in step), not in
+the generated `man/` files.
+
+## When to use
+
+- A PR's `Roxygen` / `Man Pages` check is red.
+- Someone asks "fix the roxygen / man pages failure on PR #NNN".
+
+Do not use this for spellcheck, lint, or test failures — those are different
+checks.
+
+## Inputs you need
+
+- The PR number (or the workflow run / job id) whose roxygen job failed.
+
+## Workflow
+
+### 1. Read the failing job log and the reported diff
+
+Find the roxygen job for the PR's latest run and read its log. On failure it
+prints the offending diff, for example:
+
+```
+Manuals are not up-to-date with roxygen comments!
+The following differences were noted:
+diff --git a/man/positive_mean.Rd b/man/positive_mean.Rd
+...
+roxygen2 version that was used in this workflow: 7.3.3
+Please ensure that the 'RoxygenNote' field in the DESCRIPTION file matches this version
+```
+
+Record **every** file in the diff — the check regenerates the whole package, so
+multiple `man/*.Rd`, `NAMESPACE`, and/or `DESCRIPTION` may all be listed. Also
+note the **roxygen2 version** the workflow used; a mismatch with `RoxygenNote`
+in `DESCRIPTION` can itself cause noise.
+
+### 2. Trace each stale artifact to its source
+
+Do not edit files under `man/` — they are generated (see `AGENTS.md`). Map each
+diff back to the source that produces it:
+
+- **`man/<fn>.Rd`** -> the roxygen block above `<fn>` in `R/<fn>.R`. The diff
+  shows what regeneration *would* produce; the committed `.Rd` is stale because
+  the roxygen block was changed (or should have been) and not regenerated, or
+  was edited inconsistently.
+- **`NAMESPACE`** -> `@export` / `@importFrom` / `@import` tags in the relevant
+  `R/*.R` roxygen blocks. Per `AGENTS.md`, when `@importFrom pkg fun` is
+  added/changed the matching `importFrom(pkg, fun)` line in `NAMESPACE` must be
+  updated too, and the package must be in `DESCRIPTION` Imports.
+- **`DESCRIPTION`** (`Collate:` field) -> file renames/additions or `@include`
+  tags; the collate order is regenerated from these.
+- **`DESCRIPTION`** (`RoxygenNote:`) -> must match the roxygen2 version the
+  workflow reported in step 1.
+
+### 3. Fix the source so regeneration matches the commit
+
+For each artifact, correct the **source** so that running roxygenize would
+produce exactly what the diff shows should be there:
+
+- **Content diffs in `.Rd`** (title, `@param`, `@return`, `@examples`,
+  `@details`) -> edit the corresponding roxygen tags in `R/*.R` so they match.
+  Common causes: a new/renamed function argument without a matching `@param`, a
+  changed return value without an updated `@return`, or a description edited in
+  the `.Rd` by hand instead of in the source.
+- **Export/import diffs in `NAMESPACE`** -> add/remove the `@export` or
+  `@importFrom` tag in the roxygen block, then apply the matching change to
+  `NAMESPACE` by hand (the project maintains these together, since the agent
+  cannot run `devtools::document()`). Confirm any imported package is in
+  `DESCRIPTION` Imports.
+- **`Collate` diffs** -> add the missing `@include`, or update the field to the
+  regenerated order.
+- **`RoxygenNote` mismatch** -> set `RoxygenNote` in `DESCRIPTION` to the version
+  the workflow reported. Do not fabricate a version; use the one from the log.
+
+Follow the project's roxygen conventions in `AGENTS.md` (exported functions need
+`@param`, `@return`, `@export`; keep `zzz.R` globals sorted; etc.).
+
+### 4. Verify what you can, and report
+
+You cannot run R, so you cannot run
+`roxygen2::roxygenize()` / `devtools::document()` locally — the generated `man/`
+and `NAMESPACE` cannot be produced here, so **the regenerated files themselves
+must be created by a developer running `devtools::document()`**, and final
+verification is the CI re-run.
+
+Before handing off:
+
+- Confirm each source change (roxygen tags, `NAMESPACE` lines, `DESCRIPTION`
+  fields) is consistent with what the diff said the output should be.
+- Check `NAMESPACE` and `DESCRIPTION` Imports agree for every `@importFrom`.
+- Flag clearly that `devtools::document()` must be run and the regenerated
+  `man/*`/`NAMESPACE` committed — the source edits alone will not turn the check
+  green unless the generated files are also regenerated and pushed.
+
+Then report per artifact: the file, the source it traces to, and the fix
+applied. Example:
+
+```
+- man/positive_mean.Rd -> R/positive_mean.R: added @param na.rm (new argument)
+- NAMESPACE -> R/foo.R: added @importFrom dplyr filter + importFrom(dplyr,filter)
+- DESCRIPTION RoxygenNote -> set to 7.3.3 to match the workflow
+- ACTION REQUIRED: run devtools::document() and commit man/ + NAMESPACE
+```
+
+## Notes and limits
+
+- The check regenerates the whole package, so a stale artifact can originate
+  from the base branch rather than the PR's diff. Note when the cause is
+  inherited.
+- Never edit `man/` or `NAMESPACE`/`DESCRIPTION` generated content to
+  "match" without fixing the roxygen source — the next regeneration would just
+  revert it.
+- Do not use `[skip lint]` (which also skips this job) to get a green run.
+- The agent's source edits are necessary but **not sufficient**: a developer
+  must run `devtools::document()` to produce the committed generated files.
+
+## References
+
+- `.github/workflows/man-pages.yml` — the workflow definition.
+- `AGENTS.md` — roxygen conventions, generated-file rules, NAMESPACE handling.
+- `DESCRIPTION` — Imports, Collate, RoxygenNote.

--- a/.github/skills/ci-spellcheck-triage/SKILL.md
+++ b/.github/skills/ci-spellcheck-triage/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: ci-spellcheck-triage
+description: >
+  Resolve failing Spelling / Spellcheck CI jobs. Use when a PR's spellcheck
+  job fails. Reads every flagged word from the CI log, decides per word
+  whether to reword the source or add the word to inst/WORDLIST, applies the
+  fix to all occurrences, and reports the rationale.
+---
+
+# CI Spellcheck Triage
+
+The **Spelling / Spellcheck** job (`insightsengineering/r-spellcheck-action`)
+fails when a word appears anywhere in the checked sources that is not in
+`inst/WORDLIST`. Each failing word must be resolved either by fixing the text
+or by whitelisting the word.
+
+This skill makes the decision repeatable: read the CI result, classify **every**
+flagged word, apply the fix to **all** its occurrences, and report what changed.
+
+## When to use
+
+- A PR's `Spelling / Spellcheck` check is red.
+- Someone asks "fix the spellcheck failure on PR #NNN".
+
+Do not use this for lint, tests, or roxygen failures — those are different checks.
+
+## Inputs you need
+
+- The PR number (or the workflow run / job id) whose spellcheck job failed.
+
+## Workflow
+
+### 1. Read the failing job log and extract every flagged word
+
+Find the spellcheck job for the PR's latest run and read its log. The action
+prints a table like:
+
+```
+  WORD  FOUND IN
+dev   NEWS.md:9
+foo   R/bar.R:42
+Number of misspelled words: 2
+```
+
+Collect **all** rows under `WORD / FOUND IN` — not just the first. For each,
+record the word and every `file:line` location reported. If the log is
+truncated, read from the tail so the results table (near the end, before
+`Number of misspelled words`) is visible.
+
+Do not stop after one word. The job fails on the first, but you must resolve
+the entire list so the next run is green in one pass.
+
+### 2. Confirm all occurrences in the repo
+
+CI reports the location that tripped the check, but the same word may appear in
+several files. Before deciding, search the whole repo for each word so the fix
+is complete:
+
+```
+grep -rn --word-regexp "<word>" R/ inst/ man/ vignettes/ NEWS.md README.md DESCRIPTION 2>/dev/null
+```
+
+`man/` is generated — if a word only appears there, fix its **source** roxygen
+in `R/` (see "Do not" below), not the generated file.
+
+### 3. Classify each word: reword vs. add to WORDLIST
+
+For every flagged word choose exactly one action.
+
+**Add to `inst/WORDLIST`** when the word is legitimate and intended:
+
+- A domain / PK / CDISC term or parameter code (e.g. `Cmax`, `PPTESTCD`, `AUClast`).
+- A package, function, or tool name (e.g. `PKNCA`, `roxygen`, `devtools`).
+- A recognised abbreviation or acronym used deliberately (e.g. `dev`, `BLQ`, `IV`).
+- A proper noun, unit, or symbol (e.g. `Ĉlast`, `λz`, `µg`).
+- A deliberate spelling the project already uses consistently elsewhere.
+
+**Reword the source** when the word is not something we want in the codebase:
+
+- A genuine typo or misspelling (e.g. `existance` -> `existence`).
+- A word broken by a stray character, casing, or a bad hyphenation.
+- Prose that reads better with a plain-English alternative than with a new
+  whitelist entry.
+
+When unsure, prefer **reword** for ordinary English prose and **WORDLIST** for
+technical tokens, proper nouns, symbols, and abbreviations. If a word is
+genuinely ambiguous, note it in the report and ask rather than guessing.
+
+### 4. Apply the fix for every word
+
+**Reword path — fix all occurrences, not only the CI-reported line:**
+
+- Correct the word in every file found in step 2 (`R/`, `inst/`, `NEWS.md`,
+  docs, etc.).
+- If it appeared in `man/`, fix the roxygen source in `R/` instead of the
+  generated page, and note that `devtools::document()` must be run by a
+  developer.
+- Keep meaning and surrounding formatting intact.
+
+**WORDLIST path — insert correctly:**
+
+- `inst/WORDLIST` is one word per line, sorted. Insert each new word in its
+  correct sorted position.
+- Do not add duplicates — check the word is not already present first.
+- Preserve exact casing and any special characters/symbols as they appear in
+  the source.
+- Add one entry per distinct flagged word; do not add variants that were not
+  flagged.
+
+Process the **entire** list from step 1 before finishing, so a single follow-up
+run clears the job.
+
+### 5. Verify what you can, and report
+
+You cannot run R, so you cannot run `spelling::spell_check_package()` locally —
+final verification is the re-run of the spellcheck job in CI. Before handing
+off:
+
+- Re-check that each flagged word is either corrected everywhere or present
+  once in `inst/WORDLIST`.
+- Confirm `inst/WORDLIST` stays sorted with no duplicates.
+
+Then report per word: the word, the action taken (reword or WORDLIST), and a
+one-line rationale. Example:
+
+```
+- dev     -> WORDLIST (deliberate abbreviation of "development", used in NEWS.md)
+- existance -> reword to "existence" in R/foo.R:42 and inst/shiny/bar.R:88 (typo)
+```
+
+## Notes and limits
+
+- The check runs on the whole tree, so a failing word may come from the base
+  branch, not the PR's own diff. Fixing `inst/WORDLIST` (or the source) still
+  resolves it; mention when the cause was inherited from the base branch.
+- Adding a word to `inst/WORDLIST` whitelists it repo-wide. Only do this for
+  words that are genuinely acceptable everywhere.
+- Do not edit generated files under `man/` directly (see `AGENTS.md`).
+- Do not disable the check or use `[skip spellcheck]` to get a green run.
+
+## Extending to other checks
+
+The same pattern — **read the CI result -> classify -> apply the fix to all
+occurrences -> report rationale** — applies to other LLM-resolvable checks
+(e.g. `lintr` style fixes, roxygen/NAMESPACE regeneration prompts). Keep each
+such workflow in its own skill so the decision criteria stay explicit.
+
+## References
+
+- `.github/workflows/spellcheck.yml` — the workflow definition.
+- `inst/WORDLIST` — the accepted-words list.
+- `AGENTS.md` — project conventions (generated files, code principles).


### PR DESCRIPTION
Closes #1470

### Description

Adds agent skills that resolve LLM-resolvable CI checks. Each skill follows the same pattern: read the failing CI result, classify the problem against the project's own standards, apply the fix to all affected locations, and report the per-item rationale.

**`ci-spellcheck-triage`** - resolves failing **Spelling / Spellcheck** jobs. Reads every flagged word from the job log and, per word, either rewords the source (fixing all repo-wide occurrences) or adds the word to `inst/WORDLIST` (sorted, no duplicates).

**`ci-lintr-triage`** - resolves failing **Lint / Lint** jobs. Reads each lint (linter, file, line, message) from the job log, consults `.lintr` for the expected standard, and fixes the affected files to conform without weakening the config.

**`ci-roxygen-triage`** - resolves failing **Roxygen / Man Pages** jobs. Reads the reported `man/` and `DESCRIPTION` diff, traces each stale artifact to its roxygen source in `R/` (`@param`/`@return`, `@export`/`@importFrom` with the matching `NAMESPACE` line, `Collate`, `RoxygenNote`), and fixes the source. Notes that a developer must run `devtools::document()` to regenerate the committed files, since agents cannot run R - so the source edits are necessary but not sufficient on their own.

Motivated by a base-branch "dev" spellcheck failure that broke four PRs at once, plus recurring style lints and stale-manual failures. All skills are written so the read -> classify -> apply -> report pattern extends to further checks.

### Changes

- `.github/skills/ci-spellcheck-triage/SKILL.md` - new skill.
- `.github/skills/ci-lintr-triage/SKILL.md` - new skill.
- `.github/skills/ci-roxygen-triage/SKILL.md` - new skill.

### Contributor checklist

- [x] New logic is documented
- [x] lintr / unit tests - n/a (docs only)
- [x] NEWS updated - n/a (internal tooling, no user-facing change)
