### PR TITLE
Fix TLG plot list names and units docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9193
+Version: 0.1.0.9194
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,12 @@
 
 ## Maintenance
 
+* Document the return value for the NCA Parameter Units table UI module (#1374)
 * Refresh stale in-code TODO comments whose referenced issues have since closed: the slope-selector `na.omit` guard is now documented as a defensive safety net (#641 reworked the reactivity), and the BLQ dropped-record workaround points to the current imputation-consistency issues (#1057, #1442, #1443) instead of the closed #139. Clarified why meta-mapping keys are excluded in `apply_mapping()`. Part of the TODO inventory in #1447
 
 ## Bug Fixes
 
+* `pkcg01()` and `pkcg02()` now return named plot lists by reading `id_plot` from the grouped plotting data instead of the raw input data (#1448)
 * Running NCA with "Impute Start Concentration" turned off no longer errors with `PKNCA_impute_method_FALSE not found`. When start imputation was off, the per-interval `impute` column was absent, so the BLQ step read the `impute` function argument instead of the column and built the method string `"blq, FALSE"`. The column is now always present, the reference is pinned to it, and the `update_main_intervals()` argument was renamed `impute` -> `start_impute` so it can no longer collide with the column (#1121, #1266)
 * With "Impute Start Concentration" turned off, the first interval now starts at C1 (the first sample at or after the dose) instead of the predose time. The sample feeding the start time was picked by an unordered `slice(1)`, so it could be the predose record whose negative `ARRLT` pulled the interval start before the dose (#1121)
 * The generated R-script (session code) now passes `blq_imputation_rule` to `PKNCA_update_data_object()`, matching the app. The template only applied the BLQ rule at calculation time (`PKNCA_calculate_nca()`) and omitted it during interval setup, so exported scripts did not reproduce the app's BLQ handling (#1445)

--- a/R/g_pkcg.R
+++ b/R/g_pkcg.R
@@ -318,7 +318,7 @@ pkcg01 <- function(
     }
   })
   plots %>%
-    setNames(unique(adnca[["id_plot"]]))
+    setNames(unique(adnca_grouped[["id_plot"]]))
 }
 
 # Helper Function for Title Generation
@@ -698,7 +698,7 @@ pkcg02 <- function(
     }
   })
   plots %>%
-    setNames(unique(adnca[["id_plot"]]))
+    setNames(unique(adnca_grouped[["id_plot"]]))
 
 }
 

--- a/inst/shiny/modules/tab_nca/units_table.R
+++ b/inst/shiny/modules/tab_nca/units_table.R
@@ -11,6 +11,8 @@
 #'
 #' @param id Module namespace ID.
 #'
+#' @returns A Shiny UI tag list containing the parameter units button.
+#'
 units_table_ui <- function(id) {
   ns <- NS(id)
   # Button to open a module message with the parameter units table #

--- a/tests/testthat/test-g_pkcg.R
+++ b/tests/testthat/test-g_pkcg.R
@@ -11,6 +11,8 @@ describe("pkcg01", {
   it("generates valid ggplots with LIN scale", {
     plots_lin <- pkcg01(adnca, scale = "LIN", plotly = FALSE)
     expect_equal(length(plots_lin), 3)
+    expect_length(names(plots_lin), length(plots_lin))
+    expect_true(all(nzchar(names(plots_lin))))
     vdiffr::expect_doppelganger("lin_plot1", plots_lin[[1]])
     vdiffr::expect_doppelganger("lin_plot2", plots_lin[[2]])
     vdiffr::expect_doppelganger("lin_plot3", plots_lin[[3]])
@@ -146,6 +148,8 @@ describe("pkcg02", {
       color_var_label =  attr(adnca$USUBJID, "label")
     )
     expect_equal(length(combined_plots_lin), 2)
+    expect_length(names(combined_plots_lin), length(combined_plots_lin))
+    expect_true(all(nzchar(names(combined_plots_lin))))
     vdiffr::expect_doppelganger("combined_lin_plot1", combined_plots_lin[[1]])
     vdiffr::expect_doppelganger("combined_lin_plot2", combined_plots_lin[[2]])
   })


### PR DESCRIPTION
## Issue

Closes #1448
Closes #1374

## Description

Fixes `pkcg01()` and `pkcg02()` so the returned plot lists are named from the grouped plotting data that actually contains `id_plot`. The previous `setNames()` call read `id_plot` from the raw `adnca` input, where the column does not exist, leaving the plot lists unnamed.

Also completes the NCA Parameter Units table UI roxygen header by documenting the return value.

## Definition of Done

- [x] `pkcg01()` returns one non-empty list name per generated plot
- [x] `pkcg02()` returns one non-empty list name per generated plot
- [x] Unit table UI module has `@returns` documentation
- [x] NEWS updated
- [x] Package version incremented

## How to test

Run the focused tests once R is available:

```r
devtools::test(filter = "g_pkcg")
```

Manual check:

```r
plots <- pkcg01(adnca_example, plotly = FALSE)
names(plots)
```

The names should be non-empty and correspond to the plot groups.

## Contributor checklist
- [ ] Code passes lintr checks
- [ ] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [x] R script works with the new implementation (if applicable)
- [x] Settings upload works with the new implementation (if applicable)
- [x] If any `.scss` change was done, run `data-raw/compile_css.R`
- [x] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`

## Notes to reviewer

R is not installed in this environment, so I could not run `devtools::test()` or `lintr::lint_package()` here. The commit was authored as `Gero1999 <68994823+Gero1999@users.noreply.github.com>` and contains no co-author trailer.