### PR TITLE
Fix profile-level Missing derivation in NCA results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9193
+Version: 0.1.0.9194
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 ## Bug Fixes
 
+* NCA Results now derive the `Missing` flag at the subject/profile level, so parameter-level metadata from active flag parameters can no longer duplicate rows in the pivoted results table (#1479)
 * Running NCA with "Impute Start Concentration" turned off no longer errors with `PKNCA_impute_method_FALSE not found`. When start imputation was off, the per-interval `impute` column was absent, so the BLQ step read the `impute` function argument instead of the column and built the method string `"blq, FALSE"`. The column is now always present, the reference is pinned to it, and the `update_main_intervals()` argument was renamed `impute` -> `start_impute` so it can no longer collide with the column (#1121, #1266)
 * With "Impute Start Concentration" turned off, the first interval now starts at C1 (the first sample at or after the dose) instead of the predose time. The sample feeding the start time was picked by an unordered `slice(1)`, so it could be the predose record whose negative `ARRLT` pulled the interval start before the dose (#1121)
 * The generated R-script (session code) now passes `blq_imputation_rule` to `PKNCA_update_data_object()`, matching the app. The template only applied the BLQ rule at calculation time (`PKNCA_calculate_nca()`) and omitted it during interval setup, so exported scripts did not reproduce the app's BLQ handling (#1445)

--- a/R/pivot_wider_pknca_results.R
+++ b/R/pivot_wider_pknca_results.R
@@ -283,7 +283,7 @@ pivot_wider_pknca_results <- function(myres, flag_rules = NULL, extra_vars_to_ke
 
   missing_data %>%
     summarise(
-      Missing = .extract_profile_missing_values(PPTESTCD, is.na(PPSTRES)),
+      Missing = .extract_profile_missing(PPTESTCD, is.na(PPSTRES)),
       .groups = "drop"
     )
 }
@@ -296,7 +296,7 @@ pivot_wider_pknca_results <- function(myres, flag_rules = NULL, extra_vars_to_ke
   setdiff(intersect(names(data), names(pknca_res)), result_cols)
 }
 
-.extract_profile_missing_values <- function(params, is_missing) {
+.extract_profile_missing <- function(params, is_missing) {
   missing_names <- unique(params[!is.na(is_missing) & is_missing])
   if (length(missing_names) == 0) return(NA_character_)
   paste0(missing_names, " is NA", collapse = "; ")

--- a/R/pivot_wider_pknca_results.R
+++ b/R/pivot_wider_pknca_results.R
@@ -238,18 +238,7 @@ pivot_wider_pknca_results <- function(myres, flag_rules = NULL, extra_vars_to_ke
 
   if (length(flag_cols) > 0) {
 
-    missing_flags <- pknca_res %>%
-      filter(PPTESTCD %in% flag_params,
-             type_interval == "main") %>%
-      mutate(is_missing = is.na(PPSTRES)) %>%
-      select(-PPSTRES, -PPSTRESU, -PPORRES, -PPORRESU, -type_interval)  %>%
-      pivot_wider(
-        names_from = PPTESTCD,
-        values_from = is_missing,
-        names_prefix = "missing_"
-      ) %>%
-      mutate(Missing = pmap_chr(across(starts_with("missing_")), .extract_missing_values)) %>%
-      select(-starts_with("missing_"), -exclude, -start_dose, -end_dose)
+    missing_flags <- .build_profile_missing_flags(data, pknca_res, flag_params)
 
     data <- data %>%
       left_join(missing_flags,
@@ -272,18 +261,43 @@ pivot_wider_pknca_results <- function(myres, flag_rules = NULL, extra_vars_to_ke
   data
 }
 
-# Helper function to extract missing values
-#' @noRd
-.extract_missing_values <- function(...) {
-  # Get the values for the current row
-  vals <- c(...)
-  # Get the names associated with the TRUE values
-  missing_names <- names(vals)[which(vals == TRUE)]
+# Build one Missing value per pivoted profile row. The source data is still
+# the long PKNCA result, but it is explicitly collapsed by the profile keys
+# shared with the pivoted table before joining back.
+.build_profile_missing_flags <- function(data, pknca_res, flag_params) {
+  profile_cols <- .missing_profile_cols(data, pknca_res)
 
+  missing_data <- pknca_res %>%
+    filter(PPTESTCD %in% flag_params,
+           type_interval == "main")
+
+  if (nrow(missing_data) == 0) {
+    return(data[0, profile_cols, drop = FALSE] %>%
+             mutate(Missing = character(0)))
+  }
+
+  if (length(profile_cols) > 0) {
+    missing_data <- missing_data %>%
+      group_by(across(all_of(profile_cols)))
+  }
+
+  missing_data %>%
+    summarise(
+      Missing = .extract_profile_missing_values(PPTESTCD, is.na(PPSTRES)),
+      .groups = "drop"
+    )
+}
+
+.missing_profile_cols <- function(data, pknca_res) {
+  result_cols <- c(
+    "PPTESTCD", "PPTEST", "PPSTRES", "PPSTRESU", "PPORRES", "PPORRESU",
+    "exclude", "type_interval", "start_dose", "end_dose"
+  )
+  setdiff(intersect(names(data), names(pknca_res)), result_cols)
+}
+
+.extract_profile_missing_values <- function(params, is_missing) {
+  missing_names <- unique(params[!is.na(is_missing) & is_missing])
   if (length(missing_names) == 0) return(NA_character_)
-
-  missing_names %>%
-    sub("missing_", "", .) %>%
-    paste0(" is NA") %>%
-    paste(collapse = "; ")
+  paste0(missing_names, " is NA", collapse = "; ")
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -81,7 +81,6 @@
       "is_extravascular",
       "is_halflife_used",
       "is_metabolite",
-      "is_missing",
       "is_one_dose",
       "is_requested",
       "IX",

--- a/tests/testthat/test-pivot_wider_pknca_results.R
+++ b/tests/testthat/test-pivot_wider_pknca_results.R
@@ -293,6 +293,42 @@ describe("pivot_wider_pknca_results flagging integration", {
     expect_true(grepl("LAMZSPN is NA", result$Missing[1]))
   })
 
+  it("summarises Missing once per profile when parameter metadata differs", {
+    data <- data.frame(
+      USUBJID = "S1",
+      ATPTREF = "Dose 1",
+      LAMZSPN = NA_real_,
+      R2ADJ = 0.9,
+      Exclude = NA_character_,
+      stringsAsFactors = FALSE
+    )
+    attr(data$LAMZSPN, "label") <- "Lambda z Span"
+    attr(data$R2ADJ, "label") <- "R Squared Adjusted"
+
+    pknca_res <- data.frame(
+      USUBJID = c("S1", "S1"),
+      ATPTREF = c("Dose 1", "Dose 1"),
+      PPTESTCD = c("LAMZSPN", "R2ADJ"),
+      PPTEST = c("Lambda z Span", "R Squared Adjusted"),
+      type_interval = c("main", "main"),
+      PPSTRES = c(NA_real_, 0.9),
+      # Parameter-level metadata that used to create duplicate missing rows.
+      PARAM_META = c("lambda", "fit"),
+      stringsAsFactors = FALSE
+    )
+    flag_rules <- list(
+      LAMZSPN = list(is.checked = TRUE, threshold = 1),
+      R2ADJ = list(is.checked = TRUE, threshold = 0.8)
+    )
+
+    result <- .apply_results_flags(data, pknca_res, flag_rules)
+
+    expect_equal(nrow(result), 1)
+    expect_equal(result$Missing, "LAMZSPN is NA")
+    expect_equal(result$flagged, "MISSING")
+    expect_false("PARAM_META" %in% names(result))
+  })
+
 
   it("does not create flagged column if no flags are active", {
     flag_rules <- list("R2ADJ" = list(is.checked = FALSE, threshold = 0.8))


### PR DESCRIPTION
## Issue

Closes #1479

## Description

Derive the NCA Results `Missing` value once per pivoted subject/profile row instead of allowing parameter-level metadata from the long PKNCA result to participate in the join back to the pivoted table.

This keeps the existing source of truth for missing requested flag parameters (`pknca_res$result`) but explicitly collapses those rows by the profile keys shared with the pivoted output before joining. The change prevents duplicate pivoted NCA Results rows when different active flag parameters carry different parameter-level metadata.

Also removes the now-unused `is_missing` global variable and updates the development version and NEWS entry.

## Definition of Done

- `Missing` is summarised at subject/profile level.
- Active flag parameters with missing `PPSTRES` still produce `Missing` messages.
- Parameter-level metadata can no longer duplicate pivoted result rows.
- Existing accepted/flagged/missing behavior is preserved for active flag rules.

## How to test

Run:

```r
testthat::test_file("tests/testthat/test-pivot_wider_pknca_results.R")
```

Manual check:
1. Run NCA with active flag rules.
2. Confirm the NCA Results table has one row per subject/profile.
3. Confirm the `Missing` column lists missing active flag parameters for that profile.

## Contributor checklist
- [x] Code passes lintr checks
- [x] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [x] R script works with the new implementation (if applicable)
- [x] Settings upload works with the new implementation (if applicable)
- [x] If any `.scss` change was done, run `data-raw/compile_css.R`
- [x] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`

## Notes to reviewer

`git diff --check` passes locally. R-based tests could not be run in this environment because `Rscript` is not installed.