### PR TITLE
Mark summary-excluded records in TLG listings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9195
+Version: 0.1.0.9196
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 
 ## Bug Fixes
 
+* TLG listings now mark summary-excluded records with `*` and explain the
+  marker in the footer, using `PKSUMXF` for ADNCA listings and `PPSUMXF` for
+  ADPP listings (#1482).
 * Canceling the duplicate-row resolution modal after mapping now re-enables the Data tab's Next button, and manual mapping submissions show a loading popup while processing (#1420)
 * Restored settings now ignore incomplete partial interval rows with missing or invalid start/end values before they reach the NCA setup state, preventing spurious interval parameters from uploaded settings (#1347)
 * NCA Results now derive the `Missing` flag at the subject/profile level, so parameter-level metadata from active flag parameters can no longer duplicate rows in the pivoted results table (#1479)

--- a/R/l_pkcl01.R
+++ b/R/l_pkcl01.R
@@ -83,7 +83,7 @@ l_pkcl01 <- function(
   title = paste0("Listing of PK Concentration by Treatment Group,",
                  "Subject and Nominal Time, PK Population"),
   subtitle = NULL,
-  footnote = "*: Subjects excluded from the summary table and mean plots"
+  footnote = NULL
 ) {
 
   if (!requireNamespace("rlistings", quietly = TRUE)) {
@@ -202,6 +202,18 @@ l_pkcl01 <- function(
         ifelse(. == 0, format_zero[cur_column()], as.character(.))
     ))
 
+  marker_col <- intersect(c("AVALC", "AVAL"), displaying_vars)
+  marker_col <- marker_col[marker_col %in% names(data_grouped)][1]
+  if (!is.na(marker_col) && .has_summary_excluded_records(data_grouped, "PKSUMXF")) {
+    is_summary_excluded <- !is.na(data_grouped$PKSUMXF) & data_grouped$PKSUMXF == "Y"
+    is_summary_excluded <- is_summary_excluded & !is.na(data_grouped[[marker_col]])
+    data_grouped[[marker_col]] <- as.character(data_grouped[[marker_col]])
+    data_grouped[[marker_col]][is_summary_excluded] <- paste0(
+      data_grouped[[marker_col]][is_summary_excluded],
+      .SUMMARY_EXCLUSION_MARKER
+    )
+  }
+
   # Make sure the data stays labelled
   var_labels(data_grouped) <- c(var_labels(data), id_list = "id")
   var_labels(data_grouped) <- ifelse(is.na(var_labels(data_grouped)),
@@ -234,6 +246,11 @@ l_pkcl01 <- function(
     list_titles <- gsub("<br>", "\n", parse_annotation(data = list_data,
                                                        text = subtitle))
     footnote <- parse_annotation(data = list_data, text = footnote)
+    footnote <- .append_summary_exclusion_footnote(
+      footnote,
+      list_data,
+      "PKSUMXF"
+    )
 
 
     # Build the listing object

--- a/R/l_pkcl01.R
+++ b/R/l_pkcl01.R
@@ -202,11 +202,9 @@ l_pkcl01 <- function(
         ifelse(. == 0, format_zero[cur_column()], as.character(.))
     ))
 
-  data_grouped <- .mark_sum_excl_vals(
-    data_grouped,
-    "PKSUMXF",
-    intersect(c("AVALC", "AVAL"), displaying_vars)
-  )
+  value_vars <- intersect(c("AVALC", "AVAL"), displaying_vars)
+  data_grouped <- .mark_sum_excl_vals(data_grouped, "PKSUMXF", value_vars)
+  data_grouped <- .mark_nca_excl_vals(data_grouped, "NCAXFL", value_vars)
 
   # Make sure the data stays labelled
   var_labels(data_grouped) <- c(var_labels(data), id_list = "id")
@@ -244,6 +242,11 @@ l_pkcl01 <- function(
       footnote,
       list_data,
       "PKSUMXF"
+    )
+    footnote <- .add_nca_excl_footnote(
+      footnote,
+      list_data,
+      "NCAXFL"
     )
 
 

--- a/R/l_pkcl01.R
+++ b/R/l_pkcl01.R
@@ -335,7 +335,7 @@ l_pkcl02_uri <- function(
 
   if (is.null(displaying_vars)) {
     vol_vars        <- intersect(c("VOLUME", "VOLUMEU"), names(data))
-    displaying_vars <- c("NFRLT", "AFRLT", "AVAL", vol_vars)
+    displaying_vars <- c("NFRLT", "AFRLT", vol_vars, "AVAL")
   }
 
   l_pkcl01(

--- a/R/l_pkcl01.R
+++ b/R/l_pkcl01.R
@@ -202,17 +202,11 @@ l_pkcl01 <- function(
         ifelse(. == 0, format_zero[cur_column()], as.character(.))
     ))
 
-  marker_col <- intersect(c("AVALC", "AVAL"), displaying_vars)
-  marker_col <- marker_col[marker_col %in% names(data_grouped)][1]
-  if (!is.na(marker_col) && .has_summary_excluded_records(data_grouped, "PKSUMXF")) {
-    is_summary_excluded <- !is.na(data_grouped$PKSUMXF) & data_grouped$PKSUMXF == "Y"
-    is_summary_excluded <- is_summary_excluded & !is.na(data_grouped[[marker_col]])
-    data_grouped[[marker_col]] <- as.character(data_grouped[[marker_col]])
-    data_grouped[[marker_col]][is_summary_excluded] <- paste0(
-      data_grouped[[marker_col]][is_summary_excluded],
-      .SUMMARY_EXCLUSION_MARKER
-    )
-  }
+  data_grouped <- .mark_sum_excl_vals(
+    data_grouped,
+    "PKSUMXF",
+    intersect(c("AVALC", "AVAL"), displaying_vars)
+  )
 
   # Make sure the data stays labelled
   var_labels(data_grouped) <- c(var_labels(data), id_list = "id")
@@ -246,7 +240,7 @@ l_pkcl01 <- function(
     list_titles <- gsub("<br>", "\n", parse_annotation(data = list_data,
                                                        text = subtitle))
     footnote <- parse_annotation(data = list_data, text = footnote)
-    footnote <- .append_summary_exclusion_footnote(
+    footnote <- .add_sum_excl_footnote(
       footnote,
       list_data,
       "PKSUMXF"

--- a/R/l_pkpl01.R
+++ b/R/l_pkpl01.R
@@ -84,15 +84,7 @@ l_pkpl01 <- function(
     }
 
     df$.val_fmt <- round(as.numeric(df[[value_var]]), 3)
-    if (has_summary_exclusions) {
-      is_summary_excluded <- !is.na(df$PPSUMXF) & df$PPSUMXF == "Y"
-      is_summary_excluded <- is_summary_excluded & !is.na(df$.val_fmt)
-      df$.val_fmt <- as.character(df$.val_fmt)
-      df$.val_fmt[is_summary_excluded] <- paste0(
-        df$.val_fmt[is_summary_excluded],
-        .SUMMARY_EXCLUSION_MARKER
-      )
-    }
+    df <- .mark_sum_excl_vals(df, "PPSUMXF", ".val_fmt")
 
     wide <- df %>%
       dplyr::select(dplyr::all_of(c(
@@ -132,7 +124,7 @@ l_pkpl01 <- function(
       main_title  = parse_annotation(data = df, text = title),
       subtitles   = gsub("<br>", "\n",
                          parse_annotation(data = df, text = subtitle)),
-      main_footer = .append_summary_exclusion_footnote(
+      main_footer = .add_sum_excl_footnote(
         parse_annotation(data = df, text = footnote),
         df,
         "PPSUMXF"

--- a/R/l_pkpl01.R
+++ b/R/l_pkpl01.R
@@ -71,6 +71,7 @@ l_pkpl01 <- function(
 
   .make_wide_listing <- function(df) {
     has_unit <- unit_var %in% names(df)
+    has_summary_exclusions <- .has_summary_excluded_records(df, "PPSUMXF")
 
     col_labels <- if (has_unit) {
       vapply(sort(unique(df[[param_var]])), function(p) {
@@ -82,10 +83,18 @@ l_pkpl01 <- function(
       sort(unique(df[[param_var]]))
     }
 
+    df$.val_fmt <- round(as.numeric(df[[value_var]]), 3)
+    if (has_summary_exclusions) {
+      is_summary_excluded <- !is.na(df$PPSUMXF) & df$PPSUMXF == "Y"
+      is_summary_excluded <- is_summary_excluded & !is.na(df$.val_fmt)
+      df$.val_fmt <- as.character(df$.val_fmt)
+      df$.val_fmt[is_summary_excluded] <- paste0(
+        df$.val_fmt[is_summary_excluded],
+        .SUMMARY_EXCLUSION_MARKER
+      )
+    }
+
     wide <- df %>%
-      dplyr::mutate(
-        .val_fmt = round(as.numeric(.data[[value_var]]), 3)
-      ) %>%
       dplyr::select(dplyr::all_of(c(
         intersect(listgroup_vars, names(df)),
         grouping_vars, param_var, ".val_fmt"
@@ -96,7 +105,7 @@ l_pkpl01 <- function(
         # When a subject has multiple rows for the same PARAM (e.g. multi-
         # interval ADPP), take the first value rather than creating list-columns.
         values_fn   = dplyr::first,
-        values_fill = NA_real_
+        values_fill = if (has_summary_exclusions) NA_character_ else NA_real_
       )
 
     param_cols <- sort(unique(df[[param_var]]))
@@ -123,7 +132,11 @@ l_pkpl01 <- function(
       main_title  = parse_annotation(data = df, text = title),
       subtitles   = gsub("<br>", "\n",
                          parse_annotation(data = df, text = subtitle)),
-      main_footer = parse_annotation(data = df, text = footnote)
+      main_footer = .append_summary_exclusion_footnote(
+        parse_annotation(data = df, text = footnote),
+        df,
+        "PPSUMXF"
+      )
     )
   }
 

--- a/R/utils-tlg.R
+++ b/R/utils-tlg.R
@@ -15,14 +15,27 @@
 #' @noRd
 .SUMMARY_EXCLUSION_MARKER <- "*"
 
+#' NCA-exclusion marker used in TLG listings.
+#' @noRd
+.NCA_EXCLUSION_MARKER <- "#"
+
+#' Check whether a data frame contains flagged records.
+#' @param data A data frame.
+#' @param flag_var Exclusion flag column.
+#' @return Logical scalar.
+#' @noRd
+.has_flagged_records <- function(data, flag_var) {
+  flag_var %in% names(data) &&
+    any(!is.na(data[[flag_var]]) & data[[flag_var]] == "Y")
+}
+
 #' Check whether a data frame contains summary-excluded records.
 #' @param data A data frame.
 #' @param flag_var Summary-exclusion flag column.
 #' @return Logical scalar.
 #' @noRd
 .has_summary_excluded_records <- function(data, flag_var) {
-  flag_var %in% names(data) &&
-    any(!is.na(data[[flag_var]]) & data[[flag_var]] == "Y")
+  .has_flagged_records(data, flag_var)
 }
 
 #' Build the summary-exclusion listing footnote.
@@ -38,6 +51,36 @@
   )
 }
 
+#' Build the NCA-exclusion listing footnote.
+#' @param flag_var NCA-exclusion flag column.
+#' @return Character scalar.
+#' @noRd
+.nca_exclusion_footnote <- function(flag_var) {
+  paste0(
+    .NCA_EXCLUSION_MARKER,
+    ": Record excluded from NCA calculations (",
+    flag_var,
+    " = \"Y\")."
+  )
+}
+
+#' Add a listing footnote when flagged records are present.
+#' @param footnote Existing parsed footnote.
+#' @param data A data frame.
+#' @param flag_var Exclusion flag column.
+#' @param note Footnote text to append.
+#' @return Footnote vector with exclusion note appended when needed.
+#' @noRd
+.add_excl_footnote <- function(footnote, data, flag_var, note) {
+  if (!.has_flagged_records(data, flag_var)) return(footnote)
+
+  if (is.null(footnote) || length(footnote) == 0) return(note)
+  if (all(is.na(footnote) | !nzchar(footnote))) return(note)
+  if (note %in% footnote) return(footnote)
+
+  c(footnote, note)
+}
+
 #' Add the summary-exclusion listing footnote when flagged records are present.
 #' @param footnote Existing parsed footnote.
 #' @param data A data frame.
@@ -45,14 +88,51 @@
 #' @return Footnote vector with summary-exclusion note appended when needed.
 #' @noRd
 .add_sum_excl_footnote <- function(footnote, data, flag_var) {
-  if (!.has_summary_excluded_records(data, flag_var)) return(footnote)
+  .add_excl_footnote(
+    footnote,
+    data,
+    flag_var,
+    .summary_exclusion_footnote(flag_var)
+  )
+}
 
-  note <- .summary_exclusion_footnote(flag_var)
-  if (is.null(footnote) || length(footnote) == 0) return(note)
-  if (all(is.na(footnote) | !nzchar(footnote))) return(note)
-  if (note %in% footnote) return(footnote)
+#' Add the NCA-exclusion listing footnote when flagged records are present.
+#' @param footnote Existing parsed footnote.
+#' @param data A data frame.
+#' @param flag_var NCA-exclusion flag column.
+#' @return Footnote vector with NCA-exclusion note appended when needed.
+#' @noRd
+.add_nca_excl_footnote <- function(footnote, data, flag_var) {
+  .add_excl_footnote(
+    footnote,
+    data,
+    flag_var,
+    .nca_exclusion_footnote(flag_var)
+  )
+}
 
-  c(footnote, note)
+#' Mark displayed values for flagged records.
+#' @param data A data frame.
+#' @param flag_var Exclusion flag column.
+#' @param value_vars Candidate value columns, in display priority order.
+#' @param marker Marker to append.
+#' @return The input data with the marker appended to the first value column.
+#' @noRd
+.mark_excl_vals <- function(data, flag_var, value_vars, marker) {
+  value_col <- intersect(value_vars, names(data))[1]
+  if (is.na(value_col) || !.has_flagged_records(data, flag_var)) {
+    return(data)
+  }
+
+  excluded <- !is.na(data[[flag_var]]) & data[[flag_var]] == "Y"
+  excluded <- excluded & !is.na(data[[value_col]])
+  data[[value_col]] <- as.character(data[[value_col]])
+  data[[value_col]][excluded] <- paste0(
+    data[[value_col]][excluded],
+    marker
+  )
+
+  data
 }
 
 #' Mark displayed values excluded from summaries.
@@ -62,20 +142,17 @@
 #' @return The input data with the marker appended to the first value column.
 #' @noRd
 .mark_sum_excl_vals <- function(data, flag_var, value_vars) {
-  value_col <- intersect(value_vars, names(data))[1]
-  if (is.na(value_col) || !.has_summary_excluded_records(data, flag_var)) {
-    return(data)
-  }
+  .mark_excl_vals(data, flag_var, value_vars, .SUMMARY_EXCLUSION_MARKER)
+}
 
-  excluded <- !is.na(data[[flag_var]]) & data[[flag_var]] == "Y"
-  excluded <- excluded & !is.na(data[[value_col]])
-  data[[value_col]] <- as.character(data[[value_col]])
-  data[[value_col]][excluded] <- paste0(
-    data[[value_col]][excluded],
-    .SUMMARY_EXCLUSION_MARKER
-  )
-
-  data
+#' Mark displayed values excluded from NCA calculations.
+#' @param data A data frame.
+#' @param flag_var NCA-exclusion flag column.
+#' @param value_vars Candidate value columns, in display priority order.
+#' @return The input data with the marker appended to the first value column.
+#' @noRd
+.mark_nca_excl_vals <- function(data, flag_var, value_vars) {
+  .mark_excl_vals(data, flag_var, value_vars, .NCA_EXCLUSION_MARKER)
 }
 
 #' Split a data frame by grouping variables and apply a function to each subset

--- a/R/utils-tlg.R
+++ b/R/utils-tlg.R
@@ -44,7 +44,7 @@
 #' @param flag_var Summary-exclusion flag column.
 #' @return Footnote vector with summary-exclusion note appended when needed.
 #' @noRd
-.append_summary_exclusion_footnote <- function(footnote, data, flag_var) {
+.add_sum_excl_footnote <- function(footnote, data, flag_var) {
   if (!.has_summary_excluded_records(data, flag_var)) return(footnote)
 
   note <- .summary_exclusion_footnote(flag_var)
@@ -53,6 +53,29 @@
   if (note %in% footnote) return(footnote)
 
   c(footnote, note)
+}
+
+#' Mark displayed values excluded from summaries.
+#' @param data A data frame.
+#' @param flag_var Summary-exclusion flag column.
+#' @param value_vars Candidate value columns, in display priority order.
+#' @return The input data with the marker appended to the first value column.
+#' @noRd
+.mark_sum_excl_vals <- function(data, flag_var, value_vars) {
+  value_col <- intersect(value_vars, names(data))[1]
+  if (is.na(value_col) || !.has_summary_excluded_records(data, flag_var)) {
+    return(data)
+  }
+
+  excluded <- !is.na(data[[flag_var]]) & data[[flag_var]] == "Y"
+  excluded <- excluded & !is.na(data[[value_col]])
+  data[[value_col]] <- as.character(data[[value_col]])
+  data[[value_col]][excluded] <- paste0(
+    data[[value_col]][excluded],
+    .SUMMARY_EXCLUSION_MARKER
+  )
+
+  data
 }
 
 #' Split a data frame by grouping variables and apply a function to each subset

--- a/R/utils-tlg.R
+++ b/R/utils-tlg.R
@@ -45,7 +45,7 @@
 .summary_exclusion_footnote <- function(flag_var) {
   paste0(
     .SUMMARY_EXCLUSION_MARKER,
-    ": Record excluded from summary tables and plots (",
+    " Record excluded from summary tables and plots (",
     flag_var,
     " = \"Y\")."
   )
@@ -58,10 +58,39 @@
 .nca_exclusion_footnote <- function(flag_var) {
   paste0(
     .NCA_EXCLUSION_MARKER,
-    ": Record excluded from NCA calculations (",
+    " Record excluded from NCA calculations (",
     flag_var,
-    " = \"Y\")."
+    " = \"Y\" or NCA exclude reason present)."
   )
+}
+
+#' Identify rows excluded from NCA calculations.
+#' @param data A data frame.
+#' @param flag_var NCA-exclusion flag column.
+#' @param reason_var Raw PKNCA exclusion-reason column.
+#' @return Logical vector.
+#' @noRd
+.nca_excl_rows <- function(data, flag_var, reason_var = "exclude") {
+  excluded <- rep(FALSE, nrow(data))
+
+  if (flag_var %in% names(data)) {
+    excluded <- excluded | (!is.na(data[[flag_var]]) & data[[flag_var]] == "Y")
+  }
+  if (reason_var %in% names(data)) {
+    reason <- as.character(data[[reason_var]])
+    excluded <- excluded | (!is.na(reason) & nzchar(reason))
+  }
+
+  excluded
+}
+
+#' Check whether a data frame contains NCA-excluded records.
+#' @param data A data frame.
+#' @param flag_var NCA-exclusion flag column.
+#' @return Logical scalar.
+#' @noRd
+.has_nca_excl_records <- function(data, flag_var) {
+  any(.nca_excl_rows(data, flag_var))
 }
 
 #' Add a listing footnote when flagged records are present.
@@ -103,12 +132,13 @@
 #' @return Footnote vector with NCA-exclusion note appended when needed.
 #' @noRd
 .add_nca_excl_footnote <- function(footnote, data, flag_var) {
-  .add_excl_footnote(
-    footnote,
-    data,
-    flag_var,
-    .nca_exclusion_footnote(flag_var)
-  )
+  note <- .nca_exclusion_footnote(flag_var)
+  if (!.has_nca_excl_records(data, flag_var)) return(footnote)
+  if (is.null(footnote) || length(footnote) == 0) return(note)
+  if (all(is.na(footnote) | !nzchar(footnote))) return(note)
+  if (note %in% footnote) return(footnote)
+
+  c(footnote, note)
 }
 
 #' Mark displayed values for flagged records.
@@ -152,7 +182,18 @@
 #' @return The input data with the marker appended to the first value column.
 #' @noRd
 .mark_nca_excl_vals <- function(data, flag_var, value_vars) {
-  .mark_excl_vals(data, flag_var, value_vars, .NCA_EXCLUSION_MARKER)
+  value_col <- intersect(value_vars, names(data))[1]
+  excluded <- .nca_excl_rows(data, flag_var)
+  if (is.na(value_col) || !any(excluded)) return(data)
+
+  excluded <- excluded & !is.na(data[[value_col]])
+  data[[value_col]] <- as.character(data[[value_col]])
+  data[[value_col]][excluded] <- paste0(
+    data[[value_col]][excluded],
+    .NCA_EXCLUSION_MARKER
+  )
+
+  data
 }
 
 #' Split a data frame by grouping variables and apply a function to each subset

--- a/R/utils-tlg.R
+++ b/R/utils-tlg.R
@@ -11,6 +11,50 @@
   warning(warningCondition(paste0(...), class = "tlg_warning"))
 }
 
+#' Summary-exclusion marker used in TLG listings.
+#' @noRd
+.SUMMARY_EXCLUSION_MARKER <- "*"
+
+#' Check whether a data frame contains summary-excluded records.
+#' @param data A data frame.
+#' @param flag_var Summary-exclusion flag column.
+#' @return Logical scalar.
+#' @noRd
+.has_summary_excluded_records <- function(data, flag_var) {
+  flag_var %in% names(data) &&
+    any(!is.na(data[[flag_var]]) & data[[flag_var]] == "Y")
+}
+
+#' Build the summary-exclusion listing footnote.
+#' @param flag_var Summary-exclusion flag column.
+#' @return Character scalar.
+#' @noRd
+.summary_exclusion_footnote <- function(flag_var) {
+  paste0(
+    .SUMMARY_EXCLUSION_MARKER,
+    ": Record excluded from summary tables and plots (",
+    flag_var,
+    " = \"Y\")."
+  )
+}
+
+#' Add the summary-exclusion listing footnote when flagged records are present.
+#' @param footnote Existing parsed footnote.
+#' @param data A data frame.
+#' @param flag_var Summary-exclusion flag column.
+#' @return Footnote vector with summary-exclusion note appended when needed.
+#' @noRd
+.append_summary_exclusion_footnote <- function(footnote, data, flag_var) {
+  if (!.has_summary_excluded_records(data, flag_var)) return(footnote)
+
+  note <- .summary_exclusion_footnote(flag_var)
+  if (is.null(footnote) || length(footnote) == 0) return(note)
+  if (all(is.na(footnote) | !nzchar(footnote))) return(note)
+  if (note %in% footnote) return(footnote)
+
+  c(footnote, note)
+}
+
 #' Split a data frame by grouping variables and apply a function to each subset
 #'
 #' Common pattern used by all TLG functions that return one output object per

--- a/inst/shiny/tlg.yaml
+++ b/inst/shiny/tlg.yaml
@@ -489,7 +489,7 @@ l_pkcl01:
       type: select
       choices: .colnames
       multiple: true
-      default: ["NFRLT", "AFRLT", "AVALC"]
+      default: ["NFRLT", "AFRLT", "AVAL"]
     .group_label_3: "Formatting"
     formatting_vars_table:
       label: "Variables formatting"

--- a/man/l_pkcl01.Rd
+++ b/man/l_pkcl01.Rd
@@ -13,7 +13,7 @@ l_pkcl01(
   title = paste0("Listing of PK Concentration by Treatment Group,",
     "Subject and Nominal Time, PK Population"),
   subtitle = NULL,
-  footnote = "*: Subjects excluded from the summary table and mean plots"
+  footnote = NULL
 )
 }
 \arguments{

--- a/tests/testthat/test-l_pkcl01.R
+++ b/tests/testthat/test-l_pkcl01.R
@@ -225,14 +225,14 @@ describe("l_pkcl01", {
     expect_equal(attr(listings$`A.Plasma.Oral`, "subtitles"),
                  "Analyte: A\nSpecimen: Plasma\nAdministration: Oral")
     expect_equal(attr(listings$`A.Plasma.Oral`, "main_footer"),
-                 "*: Subjects excluded from the summary table and mean plots")
+                 character())
     expect_equal(attr(listings$`B.Plasma.IV`, "main_title"),
                  paste0("Listing of PK Concentration by Treatment Group,",
                         "Subject and Nominal Time, PK Population"))
     expect_equal(attr(listings$`B.Plasma.IV`, "subtitles"),
                  "Analyte: B\nSpecimen: Plasma\nAdministration: IV")
     expect_equal(attr(listings$`B.Plasma.IV`, "main_footer"),
-                 "*: Subjects excluded from the summary table and mean plots")
+                 character())
 
     # Check the attributes of the columns
     expect_equal(attr(listings$`A.Plasma.Oral`$TRT01A, "label"), "Treatment")
@@ -292,6 +292,27 @@ describe("l_pkcl01", {
                displaying_vars = c("NFRLT", "AFRLT", "AVAL"),
                formatting_vars_table = no_label_table)
     )
+  })
+
+  it("marks PKSUMXF records and explains the marker in the footer", {
+    flagged_adnca <- adnca
+    flagged_adnca$PKSUMXF <- c("", "Y", "", "")
+
+    listings <- l_pkcl01(flagged_adnca,
+                         listgroup_vars = c("PARAM", "PCSPEC", "ROUTE"),
+                         grouping_vars = c("TRT01A", "USUBJID", "ATPTREF"),
+                         displaying_vars = c("NFRLT", "AFRLT", "AVAL"),
+                         footnote = "Existing footnote")
+
+    expect_equal(as.vector(listings$`A.Plasma.Oral`$AVAL), c("BLQ", "20.12*"))
+    expect_equal(
+      attr(listings$`A.Plasma.Oral`, "main_footer"),
+      c(
+        "Existing footnote",
+        "*: Record excluded from summary tables and plots (PKSUMXF = \"Y\")."
+      )
+    )
+    expect_equal(attr(listings$`B.Plasma.IV`, "main_footer"), "Existing footnote")
   })
 })
 

--- a/tests/testthat/test-l_pkcl01.R
+++ b/tests/testthat/test-l_pkcl01.R
@@ -309,7 +309,7 @@ describe("l_pkcl01", {
       attr(listings$`A.Plasma.Oral`, "main_footer"),
       c(
         "Existing footnote",
-        "*: Record excluded from summary tables and plots (PKSUMXF = \"Y\")."
+        "* Record excluded from summary tables and plots (PKSUMXF = \"Y\")."
       )
     )
     expect_equal(attr(listings$`B.Plasma.IV`, "main_footer"), "Existing footnote")
@@ -330,7 +330,28 @@ describe("l_pkcl01", {
       attr(listings$`A.Plasma.Oral`, "main_footer"),
       c(
         "Existing footnote",
-        "#: Record excluded from NCA calculations (NCAXFL = \"Y\")."
+        "# Record excluded from NCA calculations (NCAXFL = \"Y\" or NCA exclude reason present)."
+      )
+    )
+    expect_equal(attr(listings$`B.Plasma.IV`, "main_footer"), "Existing footnote")
+  })
+
+  it("marks raw PKNCA exclude records and explains the marker in the footer", {
+    flagged_adnca <- adnca
+    flagged_adnca$exclude <- c("", "Manual NCA exclusion", "", NA_character_)
+
+    listings <- l_pkcl01(flagged_adnca,
+                         listgroup_vars = c("PARAM", "PCSPEC", "ROUTE"),
+                         grouping_vars = c("TRT01A", "USUBJID", "ATPTREF"),
+                         displaying_vars = c("NFRLT", "AFRLT", "AVAL"),
+                         footnote = "Existing footnote")
+
+    expect_equal(as.vector(listings$`A.Plasma.Oral`$AVAL), c("BLQ", "20.12#"))
+    expect_equal(
+      attr(listings$`A.Plasma.Oral`, "main_footer"),
+      c(
+        "Existing footnote",
+        "# Record excluded from NCA calculations (NCAXFL = \"Y\" or NCA exclude reason present)."
       )
     )
     expect_equal(attr(listings$`B.Plasma.IV`, "main_footer"), "Existing footnote")
@@ -352,8 +373,8 @@ describe("l_pkcl01", {
       attr(listings$`A.Plasma.Oral`, "main_footer"),
       c(
         "Existing footnote",
-        "*: Record excluded from summary tables and plots (PKSUMXF = \"Y\").",
-        "#: Record excluded from NCA calculations (NCAXFL = \"Y\")."
+        "* Record excluded from summary tables and plots (PKSUMXF = \"Y\").",
+        "# Record excluded from NCA calculations (NCAXFL = \"Y\" or NCA exclude reason present)."
       )
     )
   })
@@ -403,6 +424,8 @@ describe("l_pkcl02_uri", {
   it("includes VOLUME and VOLUMEU in displaying_vars by default", {
     result <- l_pkcl02_uri(uri_data)[[1]]
     expect_true("VOLUME" %in% names(result))
+    disp_cols <- attr(result, "listing_dispcols")
+    expect_true(match("VOLUMEU", disp_cols) < match("AVAL", disp_cols))
   })
 
   it("does not include VOLUME when column is absent from data", {
@@ -430,7 +453,7 @@ describe("l_pkcl02_uri", {
 
     expect_equal(as.vector(result$AVAL), c("1.2", "3.4#"))
     expect_true(
-      "#: Record excluded from NCA calculations (NCAXFL = \"Y\")." %in%
+      "# Record excluded from NCA calculations (NCAXFL = \"Y\" or NCA exclude reason present)." %in%
         attr(result, "main_footer")
     )
   })

--- a/tests/testthat/test-l_pkcl01.R
+++ b/tests/testthat/test-l_pkcl01.R
@@ -314,6 +314,49 @@ describe("l_pkcl01", {
     )
     expect_equal(attr(listings$`B.Plasma.IV`, "main_footer"), "Existing footnote")
   })
+
+  it("marks NCAXFL records and explains the marker in the footer", {
+    flagged_adnca <- adnca
+    flagged_adnca$NCAXFL <- c("", "Y", "", "")
+
+    listings <- l_pkcl01(flagged_adnca,
+                         listgroup_vars = c("PARAM", "PCSPEC", "ROUTE"),
+                         grouping_vars = c("TRT01A", "USUBJID", "ATPTREF"),
+                         displaying_vars = c("NFRLT", "AFRLT", "AVAL"),
+                         footnote = "Existing footnote")
+
+    expect_equal(as.vector(listings$`A.Plasma.Oral`$AVAL), c("BLQ", "20.12#"))
+    expect_equal(
+      attr(listings$`A.Plasma.Oral`, "main_footer"),
+      c(
+        "Existing footnote",
+        "#: Record excluded from NCA calculations (NCAXFL = \"Y\")."
+      )
+    )
+    expect_equal(attr(listings$`B.Plasma.IV`, "main_footer"), "Existing footnote")
+  })
+
+  it("marks records excluded from both summaries and NCA calculations", {
+    flagged_adnca <- adnca
+    flagged_adnca$PKSUMXF <- c("", "Y", "", "")
+    flagged_adnca$NCAXFL <- c("", "Y", "", "")
+
+    listings <- l_pkcl01(flagged_adnca,
+                         listgroup_vars = c("PARAM", "PCSPEC", "ROUTE"),
+                         grouping_vars = c("TRT01A", "USUBJID", "ATPTREF"),
+                         displaying_vars = c("NFRLT", "AFRLT", "AVAL"),
+                         footnote = "Existing footnote")
+
+    expect_equal(as.vector(listings$`A.Plasma.Oral`$AVAL), c("BLQ", "20.12*#"))
+    expect_equal(
+      attr(listings$`A.Plasma.Oral`, "main_footer"),
+      c(
+        "Existing footnote",
+        "*: Record excluded from summary tables and plots (PKSUMXF = \"Y\").",
+        "#: Record excluded from NCA calculations (NCAXFL = \"Y\")."
+      )
+    )
+  })
 })
 
 # --- l_pkcl02_uri -----------------------------------------------------------
@@ -377,6 +420,19 @@ describe("l_pkcl02_uri", {
     result <- l_pkcl02_uri(uri_data, displaying_vars = c("NFRLT", "AVAL"))
     expect_type(result, "list")
     purrr::walk(result, ~ expect_s3_class(.x, "listing_df"))
+  })
+
+  it("marks urine records excluded from NCA calculations", {
+    flagged_data <- uri_data
+    flagged_data$NCAXFL <- c("", "Y", "", "")
+
+    result <- l_pkcl02_uri(flagged_data)[[1]]
+
+    expect_equal(as.vector(result$AVAL), c("1.2", "3.4#"))
+    expect_true(
+      "#: Record excluded from NCA calculations (NCAXFL = \"Y\")." %in%
+        attr(result, "main_footer")
+    )
   })
 
   it("passes through ... to l_pkcl01 (e.g. custom footnote)", {

--- a/tests/testthat/test-l_pkpl01.R
+++ b/tests/testthat/test-l_pkpl01.R
@@ -82,6 +82,26 @@ describe("l_pkpl01", {
     })
     purrr::walk(result, ~ expect_s3_class(.x, "listing_df"))
   })
+
+  it("marks PPSUMXF parameter values and explains the marker in the footer", {
+    flagged_data <- pkpl_data
+    flagged_data$PPSUMXF <- ""
+    flagged_data$PPSUMXF[flagged_data$USUBJID == "S1" &
+                           flagged_data$PARAM == "AUClast"] <- "Y"
+
+    result <- l_pkpl01(flagged_data, footnote = "Existing footnote")[[1]]
+    s1_row <- as.vector(result$USUBJID) == "S1"
+
+    expect_equal(as.vector(result$AUClast)[s1_row], "20*")
+    expect_equal(as.vector(result$Cmax)[s1_row], "5")
+    expect_equal(
+      attr(result, "main_footer"),
+      c(
+        "Existing footnote",
+        "*: Record excluded from summary tables and plots (PPSUMXF = \"Y\")."
+      )
+    )
+  })
 })
 
 describe("l_pkpl01_mp", {

--- a/tests/testthat/test-l_pkpl01.R
+++ b/tests/testthat/test-l_pkpl01.R
@@ -98,7 +98,7 @@ describe("l_pkpl01", {
       attr(result, "main_footer"),
       c(
         "Existing footnote",
-        "*: Record excluded from summary tables and plots (PPSUMXF = \"Y\")."
+        "* Record excluded from summary tables and plots (PPSUMXF = \"Y\")."
       )
     )
   })


### PR DESCRIPTION
## Description

- Mark summary-excluded records in ADNCA concentration listings with `*` when `PKSUMXF == "Y"`.
- Mark summary-excluded ADPP parameter values with `*` when `PPSUMXF == "Y"`.
- Append an explanatory listing footer only on listing pages that contain marked records.
- Bump the development version and add a NEWS entry.

## Related Issue(s)

Fixes #1482

## How to test

- `testthat::test_file("tests/testthat/test-l_pkcl01.R")`
- `testthat::test_file("tests/testthat/test-l_pkpl01.R")`
- `devtools::test()`

Go to TLG, generate listing with all type of exclusions (NCA TLG) for both ADNCA and ADPP. Then check the notes actually appear
