### PR TITLE
Clarify ratio PPANMETH reference and multiplier details

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: aNCA
 Title: (Pre-)Clinical NCA in a Dynamic Shiny App
-Version: 0.1.0.9195
+Version: 0.1.0.9196
 Authors@R: c(
     person("Ercan", "Suekuer", email = "ercan.suekuer@roche.com", role = "aut",
            comment = c(ORCID = "0009-0001-1626-1526")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 ## Bug Fixes
 
+* Ratio parameter `PPANMETH` now keeps the existing `TO` wording while naming
+  the reference group explicitly, adding the ratio multiplier when it is not 1,
+  and showing `mean(<parameter>)` when the reference is summarized across
+  subjects (#1484)
 * Canceling the duplicate-row resolution modal after mapping now re-enables the Data tab's Next button, and manual mapping submissions show a loading popup while processing (#1420)
 * Restored settings now ignore incomplete partial interval rows with missing or invalid start/end values before they reach the NCA setup state, preventing spurious interval parameters from uploaded settings (#1347)
 * NCA Results now derive the `Missing` flag at the subject/profile level, so parameter-level metadata from active flag parameters can no longer duplicate rows in the pivoted results table (#1479)

--- a/R/ratio_calculations.R
+++ b/R/ratio_calculations.R
@@ -193,21 +193,27 @@ calculate_ratios.data.frame <- function(
     rowwise() %>%
     mutate(
       ppanmeth_test_groups = paste0(
-        paste(paste(ref_cols, c_across(all_of(ref_cols)), sep = ": "), collapse = ", ")
+        paste(paste(ref_cols, c_across(all_of(ref_cols)), sep = "="), collapse = ", ")
       ),
       ppanmeth_ref_groups = paste0(
         paste(
-          paste(paste0(ref_cols), c_across(all_of(paste0(ref_cols, "_ref"))), sep = ": "),
+          paste(paste0(ref_cols), c_across(all_of(paste0(ref_cols, "_ref"))), sep = "="),
           collapse = ", "
         )
       )
     ) %>%
     ungroup() %>%
     mutate(
-      PPANMETH = ifelse(
-        ppanmeth_test_groups == ppanmeth_ref_groups,
-        paste0(PPTESTCD, " TO ", PPTESTCD_ref),
-        paste0(PPTESTCD, " TO ", PPTESTCD_ref, " [", ppanmeth_ref_groups, "]")
+      PPANMETH = .ratio_ppanmeth(
+        test_param = PPTESTCD,
+        ref_param = PPTESTCD_ref,
+        ref_text = ifelse(
+          ppanmeth_test_groups == ppanmeth_ref_groups,
+          "",
+          ppanmeth_ref_groups
+        ),
+        n_ref = n,
+        multiplier = adjusting_factor
       ),
       PPTESTCD = if (!is.null(custom_pptestcd)) {
         custom_pptestcd
@@ -228,6 +234,29 @@ calculate_ratios.data.frame <- function(
     # Keep same format as the input (PKNCAresults)
     select(any_of(c(names(df_test), "PPANMETH"))) %>%
     unique()
+}
+
+.ratio_ppanmeth <- function(test_param, ref_param, ref_text, n_ref, multiplier) {
+  multiplier <- rep_len(multiplier, length(test_param))
+
+  vapply(seq_along(test_param), function(i) {
+    ref <- if (n_ref[[i]] > 1) {
+      paste0("mean(", ref_param[[i]], ")")
+    } else {
+      ref_param[[i]]
+    }
+    method <- paste0(test_param[[i]], " TO ", ref)
+
+    details <- c(
+      if (nzchar(ref_text[[i]])) paste0("reference: ", ref_text[[i]]),
+      if (!isTRUE(all.equal(multiplier[[i]], 1))) {
+        paste0("multiplier: ", format(multiplier[[i]], trim = TRUE, scientific = FALSE))
+      }
+    )
+    if (length(details) == 0) return(method)
+
+    paste0(method, " [", paste(details, collapse = "; "), "]")
+  }, character(1))
 }
 
 #' @export

--- a/tests/testthat/test-ratio_calculations.R
+++ b/tests/testthat/test-ratio_calculations.R
@@ -127,6 +127,10 @@ describe("calculate_ratios", {
 
     expect_equal(ratios$PPORRES, c(2 / 3, 4 / 5) * 2)
     expect_true(all(grepl("RACMAX", ratios$PPTESTCD)))
+    expect_equal(
+      unique(ratios$PPANMETH),
+      "CMAX TO CMAX [reference: PARAM=A; multiplier: 2]"
+    )
   })
 
   it("handles unit conversions when needed and possible to convert", {
@@ -352,6 +356,10 @@ describe("calculate_ratios", {
     expect_equal(nrow(ratios), nrow(ex_subjects))
     expect_equal(sort(ratios$PPORRES), sort(ex_subjects$PPORRES / iv_mean))
     expect_true(all(grepl("\\(mean\\)", ratios$PPTESTCD)))
+    expect_equal(
+      unique(ratios$PPANMETH),
+      "CMAX TO mean(CMAX) [reference: ROUTE=intravascular]"
+    )
   })
 
   it("if-needed uses individual match when available", {
@@ -412,6 +420,10 @@ describe("calculate_ratios", {
     expect_equal(nrow(ratios), nrow(ex_subjects))
     expect_equal(sort(ratios$PPORRES), sort(ex_subjects$PPORRES / iv_mean))
     expect_true(all(grepl("\\(mean\\)", ratios$PPTESTCD)))
+    expect_equal(
+      unique(ratios$PPANMETH),
+      "CMAX TO mean(CMAX) [reference: ROUTE=intravascular]"
+    )
   })
 
   it("if-needed uses individual where available and aggregates the rest", {
@@ -543,6 +555,10 @@ describe("calculate_table_ratios", {
     # RATIO2 should be exactly 100x RATIO1
     expect_equal(sort(r2$PPORRES), sort(r1$PPORRES) * 100, tolerance = 1e-6)
     expect_equal(nrow(r1), nrow(r2))
+    expect_equal(
+      unique(r2$PPANMETH),
+      "CMAX TO CMAX [reference: PARAM=A; multiplier: 100]"
+    )
   })
 
 


### PR DESCRIPTION
## Issue

Closes #1484

## Description

Clarifies `PPANMETH` for ratio parameters while preserving the existing `TO` wording. Ratio method text now names the reference group explicitly, includes `multiplier: <value>` when the adjusting factor is not 1, and uses `mean(<parameter>)` when the denominator/reference value is summarized across subjects.

Examples:

```text
CMAX TO CMAX [reference: PARAM=A]
CMAX TO CMAX [reference: PARAM=A; multiplier: 100]
CMAX TO mean(CMAX) [reference: ROUTE=intravascular]
```

## Definition of Done

- [x] Ratio `PPANMETH` keeps the existing `TO` style.
- [x] Reference group details are explicitly labeled as `reference`.
- [x] Adjusting factors other than 1 are explicitly labeled as `multiplier`.
- [x] Mean-reference calculations are represented as `mean(<parameter>)`.
- [x] Focused unit expectations cover the new text.

## How to test

Run:

```r
devtools::test(filter = "ratio_calculations")
lintr::lint_package()
devtools::document()
devtools::check()
```

## Contributor checklist
- [x] Code passes lintr checks
- [ ] Code passes all unit tests
- [x] New logic covered by unit tests
- [x] New logic is documented
- [x] App or package changes are reflected in NEWS
- [x] Package version is incremented
- [ ] R script works with the new implementation (if applicable)
- [ ] Settings upload works with the new implementation (if applicable)
- [ ] If any `.scss` change was done, run `data-raw/compile_css.R`
- [ ] If a package dependency was added/changed, run `data-raw/test_suggests_hidden.R`

## Notes to reviewer

Local R-based checks could not be run in this container because `R`/`Rscript` is not installed. I ran the available static checks: `git diff --check`, added-line length scan, and helper-name length scan.